### PR TITLE
Fix diffusion conditioning feature layout; add OF3 conversion tests and verification harness

### DIFF
--- a/OF3_AF3_PORTING_NOTES.md
+++ b/OF3_AF3_PORTING_NOTES.md
@@ -42,6 +42,7 @@ or apply the same algorithm.
 | `network/diffusion_transformer.py` | Per-block pair LayerNorm + linear projection branch | OF3's `AttentionPairBias` contains its own `layer_norm_z` + `linear_z` per block; AF3 originally used a single shared LN before the entire block stack |
 | `network/diffusion_head.py` | Fourier `w`/`b` loaded as Haiku params instead of AF3's hardcoded constants | OF3 stores these as `register_buffer` (saved to `state_dict`); we convert them directly from the checkpoint so AF3's hardcoded JAX constants are never used |
 | `network/noise_level_embeddings.py` | Optional `weight`/`bias` args added to `noise_embeddings()` | Allows passing the converted Fourier values from `diffusion_head` instead of falling back to AF3's hardcoded values |
+| `network/diffusion_head.py` | Two zero columns re-inserted into `features_1d` | OF3's restype/profile blocks carry 32 classes to AF3's 31. Everywhere else the extra class is simply dropped from the weights — a zero input column contributes nothing to a bare `Linear`. Here it cannot be: `single_cond_initial_norm` is a LayerNorm, which maps a zero input to −mean/std, so OF3 always adds a trained contribution through those columns *and* normalises over 833 channels rather than 831. Dropping them cost ~1.6e-3 relative error in the diffusion single conditioning (verified: rel 2.2e-3 → 3.4e-7 against the OF3 module) |
 
 ---
 
@@ -101,6 +102,80 @@ So mapping `linear_i → left` is **correct in the trunk and wrong in the confid
 **Symptom**: a swap here transposes the pair embedding that the confidence pairformer starts from. `PAE` is where it shows: it is the only asymmetric confidence output — PDE is explicitly symmetrized (`logits + logitsᵀ`), and pLDDT / experimentally-resolved come from the single representation. pTM and ipTM are derived from `pae_probs`, so they were affected as well.
 
 **Checked and confirmed consistent** (no fix needed): the PAE/PDE bin decoding — AF3's `linspace(0, 31.0, 63)` + half-step + catch-all and OF3's `get_bin_centers(0, 32, 64)` both yield centers `0.25, 0.75, …, 31.75`; and the representative-atom choice feeding `linear_distance` — AF3's pseudo-beta (CB, CA for Gly, C4 for purines, C2 for pyrimidines, atom 0 for ligands) matches OF3's `get_token_representative_atoms` exactly.
+
+---
+
+## Verification
+
+The conversion was audited three ways, using the scripts in
+`scripts/of3_verification/` (see the README there). They need the OF3 checkpoint
+plus, for the module comparisons, an importable `openfold3`. The fast unit tests
+are in `src/alphafold3/model/of3_weight_converter_test.py`.
+
+**Weight coverage.** Instrumenting `_get`/`_has` over a full conversion shows
+4172 of 4936 checkpoint tensors are read. The remaining 764 are all under
+`sample_diffusion.*`, which is a bit-identical duplicate of `diffusion_module.*`
+(763 pairs compared, max|Δ| = 0), plus `version_tensor`. No tensor is silently
+dropped and no key is probed without being used.
+
+**Structural comparison against real AF3 params.** Every converted array matches
+the native `af3.bin.zst` parameter tree in name and shape, except:
+* the diffusion transformer, which legitimately differs under `of3_weights`
+  (`__layer_stack_no_per_layer` because the OF3 branch omits
+  `with_per_layer_inputs=True`; per-block `pair_input_layer_norm` /
+  `pair_logits_projection` inside the stack; the two Fourier params), and
+* `single_cond_initial_norm` / `single_cond_initial_projection`, which are 833
+  rather than 831 rows for the LayerNorm reason described above.
+
+Zero shape mismatches elsewhere also rules out every head-dimension swap, since
+`num_head != head_dim` in all attention configs.
+
+**Numerical module comparison.** Real OF3 PyTorch modules were run against the
+real AF3 Haiku modules loaded with converted weights, on identical inputs. This
+is what catches the error classes no shape check can see: square-matrix
+transposes, SwiGLU gate-vs-value order, and block ordering within a layer stack.
+
+| module | relative error |
+|---|---|
+| trunk PairFormer block (0 and 47 of 48) | 2e-5 |
+| MSA module block (0 and 3 of 4) | 3e-6 |
+| diffusion transformer (all 24 blocks) | 3e-5 |
+| template pair-stack block (0 and 1) | 2e-6 |
+| confidence pairformer block (0 and 3 of 4) | 1e-5 |
+| diffusion conditioning (Algorithm 21) | 4e-7 |
+| trunk/MSA input embeddings, confidence pair embed | 1e-5 |
+| pae / pde / plddt / experimentally-resolved / distogram heads | exactly 0 |
+
+Testing both ends of each stack confirms block order is not reversed. Residuals
+are float32 accumulation noise; each harness was validated to *fail* when a
+single weight is deliberately transposed or scaled. This covers 99% of the 368M
+converted parameters (364.7M). The remaining 1% is the atom cross-attention
+transformers (2.81M), the atom feature embedders (0.60M) and evoformer
+miscellany (0.32M — prev embeddings, relpos, bond embedding, template output);
+AF3's `CrossAttTransformer` needs a constructed `queries_to_keys` gather layout,
+and a hand-built stand-in risks a false result more than it buys confidence.
+
+### Benign asymmetries confirmed during the audit
+
+* **`_stack_blocks` zero-fills** any key a later block lacks. This fires for
+  real: OF3's last MSA block drops `msa_att_row`/`msa_transition`
+  (`last_block=True`). Zero weights make AF3's corresponding sub-modules output
+  exactly zero, so adding them is a true skip — the MSA output difference for
+  that block is 0. Correct, but note it would also silently hide a genuine
+  omission.
+* **pLDDT / experimentally-resolved heads** are sized for 23 atoms per token in
+  OF3 versus AF3's 24, and are zero-padded. The padded slot is unreachable: the
+  largest standard residue is RNA G with 23 heavy atoms, and non-standard
+  residues are atomized to one atom per token.
+* **The non-`_1` atom pair-conditioning params are dead.** AF3 calls
+  `token_atoms_single_cond, _ = _per_atom_conditioning(...)`, discarding that
+  site's pair output, so only the `_1` copies (the real queries×keys
+  conditioning) matter. Writing OF3's single weight set into both is harmless.
+* **Relative-position encoding layouts agree**: both are
+  `[rel_pos(66) | rel_token(66) | same_entity(1) | rel_chain(6)]` with identical
+  clipping and out-of-range sentinels, so `linear_relpos` needs no reordering.
+  Verified numerically via the diffusion conditioning, which feeds relpos and the
+  trunk pair rep through one linear.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ wheel.exclude = [
     "**.pyx",
     "**/CMakeLists.txt",
     "**.cc",
-    "**.h"
+    "**.h",
+    "**_test.py"
 ]
 sdist.include = [
     "LICENSE",
@@ -63,7 +64,7 @@ sdist.include = [
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.setuptools_scm]
-fallback_version = "3.1.3"
+fallback_version = "3.1.4"
 
 [tool.cibuildwheel]
 build = "cp3*-manylinux_x86_64"

--- a/scripts/of3_verification/README.md
+++ b/scripts/of3_verification/README.md
@@ -1,0 +1,84 @@
+# OF3 → AF3 conversion verification
+
+Manual verification harness for `src/alphafold3/model/of3_weight_converter.py`.
+These are **not** unit tests and do not run in CI — they need a real OpenFold3
+checkpoint and, for the module comparisons, an importable `openfold3`. The fast
+unit tests that do run unattended live in
+`src/alphafold3/model/of3_weight_converter_test.py`.
+
+Run them after any change to the converter or to an `of3_weights`-gated branch in
+the model. Between them they caught four real porting bugs; see
+`OF3_AF3_PORTING_NOTES.md` for the findings.
+
+## Prerequisites
+
+| variable | meaning | fallback |
+|---|---|---|
+| `OF3_CHECKPOINT` | OpenFold3 `.pt` checkpoint | `../af3_of3/weights/of3-p2-155k.pt` |
+| `OPENFOLD3_PATH` | checkout of `aqlaboratory/openfold3` | `../openfold3` |
+| `AF3_NATIVE_DIR` | directory with native AF3 `af3.bin.zst` | `../af3_of3/weights/af3_native` |
+
+Fallbacks assume the repos are siblings. `torch` is required throughout; `jax` +
+`haiku` for the `compare_*` scripts; `AF3_NATIVE_DIR` is optional (only
+`audit_structure.py` uses it, and it degrades gracefully).
+
+The public checkpoint is at `s3://openfold/staging/of3-p2-155k.pt` (no sign-in).
+
+## Structural audits
+
+Cheap, and they catch dropped or misnamed weights.
+
+```
+python3 audit_structure.py     # unread tensors; diff vs native AF3 names/shapes
+python3 audit_probed.py        # as above, but distinguishes _has() probes from _get() reads;
+                               # also lists square matrices (shape-invisible transposes)
+python3 audit_unconsumed.py    # proves the unread tensors are the sample_diffusion duplicates
+python3 dump_param_digest.py out.json   # {param: [shape, md5]}, to diff two conversions
+```
+
+Expected: every tensor read except the `sample_diffusion.*` duplicates and
+`version_tensor`; no shape mismatches against native AF3 apart from the
+documented `of3_weights` deviations (the diffusion transformer layer-stack
+naming, and `single_cond_initial_*` at 833 rather than 831 rows).
+
+`dump_param_digest.py` is the tool for "did my converter edit change anything I
+did not intend": dump before and after, then diff the JSON.
+
+## Module comparisons
+
+These run the *real* OF3 PyTorch module and the *real* AF3 Haiku module on
+identical inputs, with converted weights, and compare outputs. This is the only
+check that catches square-matrix transposes, SwiGLU gate-vs-value order, and
+block ordering inside a layer stack — none of which change any shape.
+
+```
+python3 compare_pair_features.py            # trunk/MSA input embeddings, confidence pair embed, template aatype
+python3 compare_pairformer_block.py [i]     # trunk PairFormer block i (default 0; try 0 and 47)
+python3 compare_msa_block.py [i]            # MSA module block i (try 0 and 3 — the last drops the MSA update)
+python3 compare_template_block.py [i]       # template pair-stack block i
+python3 compare_confidence_pairformer.py [i] # confidence-head pairformer block i (the PAE path)
+python3 compare_diffusion_transformer.py    # all 24 diffusion transformer blocks
+python3 compare_diffusion_conditioning.py   # Algorithm 21, incl. the relpos feature layout
+```
+
+Expect relative errors around 1e-5 or below (float32 accumulation noise) and
+Pearson r of 1.00000000. Absolute magnitudes look large because the random
+inputs are not in-distribution; judge by the *relative* error.
+
+Each `compare_*` script honours `SABOTAGE=1`, which perturbs one weight so you
+can confirm the harness actually discriminates before trusting a pass:
+
+```
+SABOTAGE=1 python3 compare_pairformer_block.py     # expect MISMATCH, rel ~0.4
+```
+
+Always sanity-check with `SABOTAGE=1` when adapting a script to a new module —
+it is easy to write a comparison that passes because it is testing nothing.
+
+## Coverage
+
+The comparisons cover ~99% of the 368M converted parameters. Not covered: the
+atom cross-attention transformers and atom feature embedders (~3.4M), because
+AF3's `CrossAttTransformer` needs a constructed `queries_to_keys` gather layout —
+a hand-built stand-in risks a false result more than it buys confidence. Those
+parameters are covered by the structural audits only.

--- a/scripts/of3_verification/_paths.py
+++ b/scripts/of3_verification/_paths.py
@@ -1,0 +1,76 @@
+"""Path resolution shared by the OF3 verification scripts.
+
+Everything is overridable by environment variable so the scripts are not tied to
+one machine:
+
+  OF3_CHECKPOINT   path to the OpenFold3 .pt checkpoint
+  AF3_NATIVE_DIR   directory holding native AF3 params (af3.bin.zst), optional
+  OPENFOLD3_PATH   checkout of aqlaboratory/openfold3, for the module comparisons
+
+Each falls back to a sibling-of-the-repo layout:
+
+  <parent>/alphafold3          <- this repository
+  <parent>/openfold3           <- OF3 source
+  <parent>/af3_of3/weights/    <- of3-p2-155k.pt, af3_native/
+"""
+
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(_HERE, '..', '..'))
+_PARENT = os.path.dirname(REPO_ROOT)
+
+_CHECKPOINT_FALLBACKS = (
+    os.path.join(_PARENT, 'af3_of3', 'weights', 'of3-p2-155k.pt'),
+)
+_NATIVE_FALLBACKS = (os.path.join(_PARENT, 'af3_of3', 'weights', 'af3_native'),)
+_OPENFOLD3_FALLBACKS = (os.path.join(_PARENT, 'openfold3'),)
+
+
+def _first_existing(*candidates: str | None) -> str | None:
+  return next((c for c in candidates if c and os.path.exists(c)), None)
+
+
+def add_import_paths(*, require_openfold3: bool = False) -> None:
+  """Put this repo's src/ (and optionally openfold3) on sys.path."""
+  sys.path.insert(0, os.path.join(REPO_ROOT, 'src'))
+  of3_src = _first_existing(
+      os.environ.get('OPENFOLD3_PATH'), *_OPENFOLD3_FALLBACKS
+  )
+  if of3_src:
+    sys.path.insert(0, of3_src)
+  elif require_openfold3:
+    raise SystemExit(
+        'This script needs the openfold3 source. Set $OPENFOLD3_PATH to a '
+        'checkout of aqlaboratory/openfold3.'
+    )
+
+
+def checkpoint() -> str:
+  """Path to the OF3 checkpoint, or exit with an explanatory message."""
+  path = _first_existing(
+      os.environ.get('OF3_CHECKPOINT'), *_CHECKPOINT_FALLBACKS
+  )
+  if not path:
+    raise SystemExit(
+        'No OF3 checkpoint found. Set $OF3_CHECKPOINT to an OpenFold3 .pt file '
+        '(e.g. s3://openfold/staging/of3-p2-155k.pt).'
+    )
+  return path
+
+
+def af3_native_dir() -> str | None:
+  """Directory of native AF3 params, or None if unavailable."""
+  return _first_existing(
+      os.environ.get('AF3_NATIVE_DIR'), *_NATIVE_FALLBACKS
+  )
+
+
+def no_cuda_autocast() -> None:
+  """Neutralise OF3's `torch.amp.autocast(device_type='cuda')` blocks on CPU."""
+  import contextlib
+
+  import torch
+
+  torch.amp.autocast = lambda *a, **k: contextlib.nullcontext()

--- a/scripts/of3_verification/audit_probed.py
+++ b/scripts/of3_verification/audit_probed.py
@@ -1,0 +1,54 @@
+"""Close the coverage hole: keys probed with _has() but whose values are never
+read via _get() would have counted as 'accessed'. Track them separately.
+
+Also enumerate the shape-invariant risk surface: square weight matrices, where
+a missing or spurious transpose cannot be caught by any shape check.
+"""
+
+import collections
+import sys
+
+import _paths
+
+_paths.add_import_paths()
+
+from alphafold3.model import of3_weight_converter as conv
+
+got, probed = set(), set()
+_orig_get, _orig_has = conv._get, conv._has
+conv._get = lambda sd, k: (got.add(k), _orig_get(sd, k))[1]
+conv._has = lambda sd, k: (probed.add(k), _orig_has(sd, k))[1]
+
+sd = conv.load_of3_checkpoint(_paths.checkpoint())
+conv.map_of3_to_af3(sd)
+
+real = set(sd)
+never_read = sorted(real - got)
+probed_not_read = sorted((real & probed) - got)
+
+print(f'tensors: {len(real)}   read via _get: {len(real & got)}')
+print(f'never read: {len(never_read)}')
+print(f'  of those, probed by _has but value never used: {len(probed_not_read)}')
+
+non_dup = [k for k in never_read if not k.startswith('sample_diffusion.')]
+print(f'\nnever-read tensors outside the duplicated sample_diffusion subtree: '
+      f'{len(non_dup)}')
+for k in non_dup:
+  print(f'  {k}  {tuple(sd[k].shape)}')
+
+probed_non_dup = [k for k in probed_not_read if not k.startswith('sample_diffusion.')]
+print(f'\nprobed-but-unused outside sample_diffusion: {len(probed_non_dup)}')
+for k in probed_non_dup:
+  print(f'  {k}  {tuple(sd[k].shape)}')
+
+print('\n=== square weight matrices (transpose errors are shape-invisible) ===')
+squares = collections.Counter()
+for k, v in sd.items():
+  if k.startswith('sample_diffusion.'):
+    continue
+  shape = tuple(v.shape)
+  if len(shape) == 2 and shape[0] == shape[1]:
+    squares['.'.join('N' if p.isdigit() else p for p in k.split('.'))] = shape
+print(f'{len(squares)} distinct square-matrix patterns:')
+for pattern, shape in sorted(squares.items()):
+  print(f'  {pattern}   {shape}')

--- a/scripts/of3_verification/audit_structure.py
+++ b/scripts/of3_verification/audit_structure.py
@@ -1,0 +1,94 @@
+"""Structural audit of the OF3 -> AF3 conversion.
+
+1. Which OF3 checkpoint tensors does the converter never read? (unconsumed
+   weights = something the AF3 side is silently getting from its own init)
+2. How does the converted param tree compare to REAL AF3 native params —
+   missing scopes, extra scopes, shape mismatches?
+"""
+
+import collections
+import sys
+
+import _paths
+
+_paths.add_import_paths()
+
+import numpy as np
+from alphafold3.model import of3_weight_converter as conv
+
+OF3_CKPT = _paths.checkpoint()
+AF3_NATIVE = _paths.af3_native_dir()
+
+# ── 1. instrument _get/_has to record every checkpoint key touched ────────────
+accessed = set()
+_orig_get, _orig_has = conv._get, conv._has
+
+
+def _get_logged(sd, key):
+  accessed.add(key)
+  return _orig_get(sd, key)
+
+
+def _has_logged(sd, key):
+  accessed.add(key)
+  return _orig_has(sd, key)
+
+
+conv._get, conv._has = _get_logged, _has_logged
+
+print(f'Loading OF3 checkpoint {OF3_CKPT}')
+sd = conv.load_of3_checkpoint(OF3_CKPT)
+params = conv.map_of3_to_af3(sd)
+print(f'  {len(sd)} checkpoint tensors, {len(params)} converted scopes')
+
+unconsumed = sorted(set(sd) - accessed)
+print(f'\n=== 1. Checkpoint tensors never read: {len(unconsumed)} ===')
+groups = collections.Counter()
+for key in unconsumed:
+  # Collapse block indices so the report is readable.
+  parts = [p if not p.isdigit() else 'N' for p in key.split('.')]
+  groups['.'.join(parts)] += 1
+for pattern, count in sorted(groups.items()):
+  shape = tuple(sd[next(k for k in unconsumed
+                        if [p if not p.isdigit() else 'N'
+                            for p in k.split('.')] == pattern.split('.'))].shape)
+  print(f'  x{count:<4d} {pattern}   {shape}')
+
+# ── 2. compare against real AF3 native params ────────────────────────────────
+print(f'\n=== 2. Structural diff vs AF3 native params ===')
+try:
+  from alphafold3.model import params as af3_params
+
+  native = af3_params.get_model_haiku_params(AF3_NATIVE)
+except Exception as exc:  # noqa: BLE001
+  print(f'  could not load AF3 native params: {exc!r}')
+  sys.exit(0)
+
+native_flat = {
+    f'{scope}/{name}': np.asarray(arr).shape
+    for scope, entries in native.items()
+    for name, arr in entries.items()
+}
+conv_flat = {
+    f'{scope}/{name}': np.asarray(arr).shape
+    for scope, entries in params.items()
+    for name, arr in entries.items()
+}
+print(f'  native: {len(native_flat)} arrays, converted: {len(conv_flat)} arrays')
+
+missing = sorted(set(native_flat) - set(conv_flat))
+extra = sorted(set(conv_flat) - set(native_flat))
+mismatched = sorted(
+    k for k in set(native_flat) & set(conv_flat)
+    if native_flat[k] != conv_flat[k]
+)
+
+print(f'\n  -- in AF3 but NOT produced by converter: {len(missing)}')
+for k in missing:
+  print(f'     {k}  {native_flat[k]}')
+print(f'\n  -- produced by converter but NOT in AF3: {len(extra)}')
+for k in extra:
+  print(f'     {k}  {conv_flat[k]}')
+print(f'\n  -- SHAPE MISMATCH: {len(mismatched)}')
+for k in mismatched:
+  print(f'     {k}  af3={native_flat[k]}  converted={conv_flat[k]}')

--- a/scripts/of3_verification/audit_unconsumed.py
+++ b/scripts/of3_verification/audit_unconsumed.py
@@ -1,0 +1,69 @@
+"""Two questions about unread checkpoint tensors:
+
+1. Are any of them NOT part of the duplicated `sample_diffusion.*` subtree?
+   Those would be genuinely dropped weights.
+2. Is `sample_diffusion.diffusion_module.X` numerically identical to
+   `diffusion_module.X`? OF3 uses the sample_diffusion copy at inference, so if
+   they differ the converter is reading the wrong one.
+"""
+
+import collections
+import sys
+
+import _paths
+
+_paths.add_import_paths()
+
+import numpy as np
+from alphafold3.model import of3_weight_converter as conv
+
+accessed = set()
+_orig_get, _orig_has = conv._get, conv._has
+conv._get = lambda sd, k: (accessed.add(k), _orig_get(sd, k))[1]
+conv._has = lambda sd, k: (accessed.add(k), _orig_has(sd, k))[1]
+
+sd = conv.load_of3_checkpoint(_paths.checkpoint())
+conv.map_of3_to_af3(sd)
+unconsumed = sorted(set(sd) - accessed)
+
+print(f'total tensors: {len(sd)}   unread: {len(unconsumed)}')
+
+other = [k for k in unconsumed if not k.startswith('sample_diffusion.')]
+print(f'\n=== unread and NOT under sample_diffusion.: {len(other)} ===')
+groups = collections.Counter(
+    '.'.join('N' if p.isdigit() else p for p in k.split('.')) for k in other
+)
+for pattern, count in sorted(groups.items()):
+  example = next(
+      k for k in other
+      if '.'.join('N' if p.isdigit() else p for p in k.split('.')) == pattern
+  )
+  print(f'  x{count:<4d} {pattern}   {tuple(sd[example].shape)}')
+
+print('\n=== sample_diffusion.X vs X: numerically identical? ===')
+pairs = 0
+differing = []
+for key in sd:
+  if not key.startswith('sample_diffusion.'):
+    continue
+  base = key[len('sample_diffusion.'):]
+  if base not in sd:
+    differing.append((key, 'NO COUNTERPART'))
+    continue
+  pairs += 1
+  a = sd[key].detach().float().numpy()
+  b = sd[base].detach().float().numpy()
+  if a.shape != b.shape:
+    differing.append((key, f'shape {a.shape} vs {b.shape}'))
+  else:
+    d = float(np.max(np.abs(a - b)))
+    if d > 0:
+      differing.append((key, f'max|Δ|={d:.3e}'))
+
+print(f'  compared {pairs} pairs')
+if differing:
+  print(f'  DIFFERING: {len(differing)}')
+  for k, why in differing[:20]:
+    print(f'    {k}: {why}')
+else:
+  print('  all identical -> the sample_diffusion subtree is a redundant copy')

--- a/scripts/of3_verification/compare_confidence_pairformer.py
+++ b/scripts/of3_verification/compare_confidence_pairformer.py
@@ -1,0 +1,113 @@
+"""Compare a confidence-head pairformer block (the PAE path) in both codebases.
+
+Same classes as the trunk pairformer but a different checkpoint prefix and a
+different converted scope, so it gets its own numerical check.
+
+Usage: python3 compare_confidence_pairformer.py [block_idx]  SABOTAGE=1 self-test
+"""
+
+import os
+import sys
+
+import _paths
+
+_paths.add_import_paths(require_openfold3=True)
+
+import haiku as hk
+import jax.numpy as jnp
+import numpy as np
+import torch
+
+_paths.no_cuda_autocast()
+
+from alphafold3.model import of3_weight_converter as conv   # noqa: E402
+from alphafold3.model.network import modules                # noqa: E402
+from openfold3.core.model.latent.pairformer import PairFormerBlock  # noqa: E402
+
+BLOCK = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+CKPT = _paths.checkpoint()
+N_TOKENS, C_S, C_Z = 7, 384, 128
+
+
+def main():
+  print(f'Loading {CKPT}  (confidence pairformer block {BLOCK})')
+  sd = conv.load_of3_checkpoint(CKPT)
+  params = conv.map_of3_to_af3(sd)
+
+  rng = np.random.default_rng(4)
+  z = rng.standard_normal((N_TOKENS, N_TOKENS, C_Z)).astype(np.float32) * 0.5
+  s = rng.standard_normal((N_TOKENS, C_S)).astype(np.float32) * 0.5
+  pair_mask = np.ones((N_TOKENS, N_TOKENS), dtype=np.float32)
+  seq_mask = np.ones((N_TOKENS,), dtype=np.float32)
+
+  of3 = PairFormerBlock(
+      c_s=C_S, c_z=C_Z, c_hidden_pair_bias=24, no_heads_pair_bias=16,
+      c_hidden_mul=128, c_hidden_pair_att=32, no_heads_pair=4,
+      transition_type='swiglu', transition_n=4, pair_dropout=0.25,
+      fuse_projection_weights=False, inf=1e8,
+  )
+  prefix = f'aux_heads.pairformer_embedding.pairformer_stack.blocks.{BLOCK}.'
+  sub = {k[len(prefix):]: v.detach().float()
+         for k, v in sd.items() if k.startswith(prefix)}
+  missing, unexpected = of3.load_state_dict(sub, strict=False)
+  missing = [m for m in missing if 'dropout' not in m]
+  if missing or unexpected:
+    print(f'  OF3 load: missing={missing[:5]} unexpected={unexpected[:5]}')
+  of3.eval()
+  with torch.no_grad():
+    of3_s, of3_z = of3(
+        s=torch.from_numpy(s.copy()), z=torch.from_numpy(z.copy()),
+        single_mask=torch.from_numpy(seq_mask.copy()),
+        pair_mask=torch.from_numpy(pair_mask.copy()),
+    )
+  of3_s, of3_z = of3_s.numpy(), of3_z.numpy()
+
+  from alphafold3.model import model
+  from alphafold3.model.network import confidence_head
+
+  gc = model.Model.Config().global_config
+  gc.of3_weights = True
+  gc.bfloat16 = 'none'
+  gc.flash_attention_implementation = 'xla'
+  cfg = confidence_head.ConfidenceHead.Config().pairformer
+
+  def fwd(act, pmask, single, smask):
+    return modules.PairFormerIteration(
+        cfg, gc, with_single=True, name='confidence_pairformer'
+    )(act, pmask, single, smask)
+
+  transformed = hk.without_apply_rng(hk.transform(fwd))
+  name = 'confidence_pairformer'
+  scope_prefix = next(k.split(name)[0] for k in params if name in k)
+  block_params = {
+      k[len(scope_prefix):]: {n: jnp.asarray(v[BLOCK]) for n, v in e.items()}
+      for k, e in params.items() if k.startswith(scope_prefix + name)
+  }
+  if os.environ.get('SABOTAGE'):
+    tgt = f'{name}/single_attention_gating_query'
+    block_params[tgt] = {'weights': block_params[tgt]['weights'].T}
+    print('  [sabotage] transposed', tgt)
+
+  af3_z, af3_s = transformed.apply(
+      block_params, jnp.asarray(z), jnp.asarray(pair_mask),
+      jnp.asarray(s), jnp.asarray(seq_mask),
+  )
+
+  ok = True
+  print('\nConfidence pairformer block outputs:')
+  for label, a, b in (('pair z', np.asarray(af3_z), of3_z),
+                      ('single s', np.asarray(af3_s), of3_s)):
+    diff = np.max(np.abs(a - b))
+    scale = np.max(np.abs(b))
+    rel = diff / max(scale, 1e-9)
+    corr = np.corrcoef(a.ravel(), b.ravel())[0, 1]
+    good = rel < 2e-3
+    ok &= good
+    print(f'  {"MATCH" if good else "MISMATCH":9s} {label:<9s} max|Δ| = {diff:.3e}'
+          f'   |x|max = {scale:.3f}   rel = {rel:.2e}   r = {corr:.8f}')
+  print('\nRESULT:', 'matches' if ok else 'MISMATCH')
+  return 0 if ok else 1
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/scripts/of3_verification/compare_diffusion_conditioning.py
+++ b/scripts/of3_verification/compare_diffusion_conditioning.py
@@ -1,0 +1,180 @@
+"""Compare the diffusion conditioning module (Algorithm 21) in both codebases.
+
+Covers, in one shot:
+  * the relative-position encoding feature LAYOUT (rel_pos | rel_token |
+    same_entity | rel_chain) — it is concatenated with the trunk pair rep and
+    fed to one linear, so a layout mismatch would show up here
+  * pair_cond / single_cond initial LayerNorm + projection
+  * the two pair transitions and two single transitions (the _swiglu_flat path)
+  * the Fourier noise embedding parameters converted from OF3 buffers
+  * the target_feat features_1d block reordering (_reorder_features_1d)
+
+Usage: python3 compare_diffusion_conditioning.py    SABOTAGE=1 to self-test
+"""
+
+import dataclasses
+import os
+import sys
+
+import _paths
+
+_paths.add_import_paths(require_openfold3=True)
+
+import haiku as hk
+import jax.numpy as jnp
+import numpy as np
+import torch
+
+_paths.no_cuda_autocast()
+
+from alphafold3.model import of3_weight_converter as conv        # noqa: E402
+from alphafold3.model.network import diffusion_head              # noqa: E402
+from openfold3.core.model.layers.diffusion_conditioning import (  # noqa: E402
+    DiffusionConditioning,
+)
+
+CKPT = _paths.checkpoint()
+N = 6
+C_S_INPUT, C_S, C_Z = 449, 384, 128
+SIGMA_DATA = 16.0
+
+# Two chains so asym/entity/sym distinctions are exercised, and a repeated
+# residue_index so rel_token's same_res condition fires.
+ASYM = np.array([1, 1, 1, 2, 2, 2], dtype=np.int32)
+ENTITY = np.array([1, 1, 1, 1, 1, 1], dtype=np.int32)
+SYM = np.array([1, 1, 1, 2, 2, 2], dtype=np.int32)
+RES_IDX = np.array([1, 2, 2, 1, 2, 3], dtype=np.int32)
+TOK_IDX = np.array([1, 2, 3, 4, 5, 6], dtype=np.int32)
+
+
+@dataclasses.dataclass
+class _TokenFeatures:
+  residue_index: np.ndarray
+  token_index: np.ndarray
+  asym_id: np.ndarray
+  entity_id: np.ndarray
+  sym_id: np.ndarray
+
+
+@dataclasses.dataclass
+class _Batch:
+  token_features: _TokenFeatures
+
+
+def main():
+  print(f'Loading {CKPT}')
+  sd = conv.load_of3_checkpoint(CKPT)
+  params = conv.map_of3_to_af3(sd)
+
+  rng = np.random.default_rng(11)
+  s_trunk = rng.standard_normal((N, C_S)).astype(np.float32) * 0.5
+  z_trunk = rng.standard_normal((N, N, C_Z)).astype(np.float32) * 0.5
+  s_input_of3 = rng.standard_normal((N, C_S_INPUT)).astype(np.float32) * 0.5
+  noise_level = np.array(2.0, dtype=np.float32)
+
+  # AF3's target_feat is the same features in AF3 block order. Only the atom
+  # conditioning block is populated so the residue permutation (already tested
+  # elsewhere) stays out of this comparison.
+  target_feat = np.zeros((N, 447), dtype=np.float32)
+  target_feat[:, 2 * 31 + 1:] = s_input_of3[:, :384]
+  of3_s_input = np.zeros_like(s_input_of3)
+  of3_s_input[:, :384] = s_input_of3[:, :384]
+
+  # ── OF3 reference ──
+  of3 = DiffusionConditioning(
+      c_s_input=C_S_INPUT, c_s=C_S, c_z=C_Z, sigma_data=SIGMA_DATA,
+      c_fourier_emb=256, max_relative_idx=32, max_relative_chain=2,
+      seed_fourier_emb=42,
+  )
+  prefix = 'diffusion_module.diffusion_conditioning.'
+  sub = {k[len(prefix):]: v.detach().float()
+         for k, v in sd.items() if k.startswith(prefix)}
+  missing, unexpected = of3.load_state_dict(sub, strict=False)
+  if missing or unexpected:
+    print(f'  OF3 load: missing={missing[:5]} unexpected={unexpected[:5]}')
+  of3.eval()
+  batch_of3 = {
+      'residue_index': torch.from_numpy(RES_IDX.astype(np.int64)),
+      'token_index': torch.from_numpy(TOK_IDX.astype(np.int64)),
+      'asym_id': torch.from_numpy(ASYM.astype(np.int64)),
+      'entity_id': torch.from_numpy(ENTITY.astype(np.int64)),
+      'sym_id': torch.from_numpy(SYM.astype(np.int64)),
+      'token_mask': torch.ones(N),
+  }
+  with torch.no_grad():
+    of3_s, of3_z = of3(
+        batch=batch_of3,
+        t=torch.tensor(float(noise_level)),
+        si_input=torch.from_numpy(of3_s_input.copy()),
+        si_trunk=torch.from_numpy(s_trunk.copy()),
+        zij_trunk=torch.from_numpy(z_trunk.copy()),
+        use_conditioning=True,
+    )
+  of3_s, of3_z = of3_s.numpy(), of3_z.numpy()
+
+  # ── AF3 with converted params ──
+  from alphafold3.model import model
+
+  cfg_full = model.Model.Config()
+  gc = cfg_full.global_config
+  gc.of3_weights = True
+  gc.bfloat16 = 'none'
+  gc.flash_attention_implementation = 'xla'
+  head_cfg = cfg_full.heads.diffusion
+
+  batch = _Batch(_TokenFeatures(RES_IDX, TOK_IDX, ASYM, ENTITY, SYM))
+
+  def fwd(single, pair, tfeat, nl):
+    head = diffusion_head.DiffusionHead(head_cfg, gc)
+    return head._conditioning(  # pylint: disable=protected-access
+        batch=batch,
+        embeddings={'single': single, 'pair': pair, 'target_feat': tfeat},
+        noise_level=nl,
+        use_conditioning=True,
+    )
+
+  transformed = hk.without_apply_rng(hk.transform(fwd))
+  strip = 'diffuser/~/diffusion_head/'
+  block_params = {
+      k[len(strip):]: {n: jnp.asarray(v) for n, v in e.items()}
+      for k, e in params.items() if k.startswith(strip)
+  }
+  # In the real model hk.get_parameter inside the transparent _conditioning
+  # attaches to the enclosing DiffusionHead scope; standalone it lands on '~'.
+  head_scope = params['diffuser/~/diffusion_head']
+  block_params['~'] = {
+      'fourier_embedding_weight': jnp.asarray(head_scope['fourier_embedding_weight']),
+      'fourier_embedding_bias': jnp.asarray(head_scope['fourier_embedding_bias']),
+  }
+
+  if os.environ.get('SABOTAGE'):
+    # Rotate the relpos columns to prove the feature layout is actually tested.
+    tgt = 'pair_cond_initial_projection'
+    w = np.asarray(block_params[tgt]['weights'])
+    w = np.concatenate([w[:C_Z], np.roll(w[C_Z:], 1, axis=0)], axis=0)
+    block_params[tgt] = {'weights': jnp.asarray(w)}
+    print('  [sabotage] rolled relpos rows of', tgt)
+
+  af3_s, af3_z = transformed.apply(
+      block_params, jnp.asarray(s_trunk), jnp.asarray(z_trunk),
+      jnp.asarray(target_feat), jnp.asarray(noise_level),
+  )
+
+  print('\nDiffusion conditioning outputs:')
+  ok = True
+  for label, a, b in (('single_cond', np.asarray(af3_s), of3_s),
+                      ('pair_cond', np.asarray(af3_z), of3_z)):
+    diff = np.max(np.abs(a - b))
+    scale = np.max(np.abs(b))
+    rel = diff / max(scale, 1e-9)
+    corr = np.corrcoef(a.ravel(), b.ravel())[0, 1]
+    good = rel < 2e-3
+    ok &= good
+    print(f'  {"MATCH" if good else "MISMATCH":9s} {label:<12s} max|Δ| = {diff:.3e}'
+          f'   |x|max = {scale:.3f}   rel = {rel:.2e}   r = {corr:.8f}')
+  print('\nRESULT:', 'matches' if ok else 'MISMATCH')
+  return 0 if ok else 1
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/scripts/of3_verification/compare_diffusion_transformer.py
+++ b/scripts/of3_verification/compare_diffusion_transformer.py
@@ -1,0 +1,120 @@
+"""Compare the full 24-block diffusion transformer in both implementations.
+
+This is the most heavily OF3-branched module in the AF3 code: per-block pair
+LayerNorm + projection instead of AF3's single shared pre-stack LN, plus the
+adaLN single conditioning and the flat SwiGLU conversion (_swiglu_flat) that is
+a separate code path from the pairformer's SwiGLU helper.
+
+Usage: python3 compare_diffusion_transformer.py     SABOTAGE=1 to self-test
+"""
+
+import os
+import sys
+
+import _paths
+
+_paths.add_import_paths(require_openfold3=True)
+
+import haiku as hk
+import jax.numpy as jnp
+import numpy as np
+import torch
+
+_paths.no_cuda_autocast()
+
+from alphafold3.model import of3_weight_converter as conv        # noqa: E402
+from alphafold3.model.network import diffusion_transformer       # noqa: E402
+from openfold3.core.model.layers.diffusion_transformer import (  # noqa: E402
+    DiffusionTransformer,
+)
+
+CKPT = _paths.checkpoint()
+N_TOKENS = 6
+C_A, C_S, C_Z = 768, 384, 128
+
+
+def af3_config():
+  from alphafold3.model import model
+
+  cfg = model.Model.Config()
+  gc = cfg.global_config
+  gc.of3_weights = True
+  gc.bfloat16 = 'none'
+  gc.flash_attention_implementation = 'xla'
+  return cfg.heads.diffusion.transformer, gc
+
+
+def main():
+  print(f'Loading {CKPT}')
+  sd = conv.load_of3_checkpoint(CKPT)
+  params = conv.map_of3_to_af3(sd)
+
+  rng = np.random.default_rng(2)
+  a = rng.standard_normal((N_TOKENS, C_A)).astype(np.float32) * 0.5
+  s = rng.standard_normal((N_TOKENS, C_S)).astype(np.float32) * 0.5
+  z = rng.standard_normal((N_TOKENS, N_TOKENS, C_Z)).astype(np.float32) * 0.5
+  mask = np.ones((N_TOKENS,), dtype=np.float32)
+
+  # ── OF3 reference ──
+  of3 = DiffusionTransformer(
+      c_a=C_A, c_s=C_S, c_z=C_Z, c_hidden=48, no_heads=16, no_blocks=24,
+      n_transition=2, use_ada_layer_norm=True, n_query=None, n_key=None,
+      inf=1e8,
+  )
+  prefix = 'diffusion_module.diffusion_transformer.'
+  sub = {k[len(prefix):]: v.detach().float()
+         for k, v in sd.items() if k.startswith(prefix)}
+  missing, unexpected = of3.load_state_dict(sub, strict=False)
+  if missing or unexpected:
+    print(f'  OF3 load: missing={missing[:5]} unexpected={unexpected[:5]}')
+  of3.eval()
+  with torch.no_grad():
+    of3_out = of3(
+        a=torch.from_numpy(a.copy()),
+        s=torch.from_numpy(s.copy()),
+        z=torch.from_numpy(z.copy()),
+        mask=torch.from_numpy(mask.copy()),
+    ).numpy()
+
+  # ── AF3 with converted params ──
+  cfg, gc = af3_config()
+  print(f'  AF3 config: num_blocks={cfg.num_blocks} '
+        f'super_block_size={cfg.super_block_size}')
+
+  def fwd(act, m, single_cond, pair_cond):
+    return diffusion_transformer.Transformer(cfg, gc, name='transformer')(
+        act, m, single_cond, pair_cond
+    )
+
+  transformed = hk.without_apply_rng(hk.transform(fwd))
+  scope_prefix = 'diffuser/~/diffusion_head/'
+  block_params = {
+      k[len(scope_prefix):]: {n: jnp.asarray(v) for n, v in e.items()}
+      for k, e in params.items()
+      if k.startswith(scope_prefix + 'transformer')
+  }
+  if os.environ.get('SABOTAGE'):
+    tgt = next(k for k in block_params if k.endswith('transformerq_projection'))
+    w = block_params[tgt]['weights']
+    block_params[tgt] = {**block_params[tgt], 'weights': w * 1.02}
+    print('  [sabotage] scaled', tgt)
+
+  af3_out = np.asarray(transformed.apply(
+      block_params, jnp.asarray(a), jnp.asarray(mask),
+      jnp.asarray(s), jnp.asarray(z),
+  ))
+
+  diff = np.max(np.abs(af3_out - of3_out))
+  scale = np.max(np.abs(of3_out))
+  rel = diff / max(scale, 1e-9)
+  corr = np.corrcoef(af3_out.ravel(), of3_out.ravel())[0, 1]
+  good = rel < 2e-3
+  print('\nDiffusion transformer output (24 blocks):')
+  print(f'  {"MATCH" if good else "MISMATCH":9s} a   max|Δ| = {diff:.3e}'
+        f'   |x|max = {scale:.3f}   rel = {rel:.2e}   r = {corr:.8f}')
+  print('\nRESULT:', 'matches' if good else 'MISMATCH')
+  return 0 if good else 1
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/scripts/of3_verification/compare_msa_block.py
+++ b/scripts/of3_verification/compare_msa_block.py
@@ -1,0 +1,146 @@
+"""Same idea as compare_pairformer_block.py, for the MSA module block.
+
+Covers OuterProductMean, MSA row attention with pair bias, the MSA transition,
+and the pair stack inside the MSA block.
+
+Usage: python3 compare_msa_block.py [block_idx]      SABOTAGE=1 to self-test
+"""
+
+import os
+import sys
+
+import _paths
+
+_paths.add_import_paths(require_openfold3=True)
+
+import haiku as hk
+import jax
+import jax.numpy as jnp
+import numpy as np
+import torch
+
+_paths.no_cuda_autocast()
+
+from alphafold3.model import of3_weight_converter as conv      # noqa: E402
+from alphafold3.model.network import modules                   # noqa: E402
+from openfold3.core.model.latent.msa_module import MSAModuleBlock  # noqa: E402
+
+BLOCK = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+CKPT = _paths.checkpoint()
+N_TOKENS, N_MSA = 7, 5
+C_M, C_Z = 64, 128
+
+
+def af3_config():
+  from alphafold3.model import model
+
+  cfg = model.Model.Config()
+  gc = cfg.global_config
+  gc.of3_weights = True
+  gc.bfloat16 = 'none'
+  gc.flash_attention_implementation = 'xla'
+  return cfg.evoformer.msa_stack, gc
+
+
+def build_of3_block(sd):
+  block = MSAModuleBlock(
+      c_m=C_M,
+      c_z=C_Z,
+      c_hidden_msa_att=8,
+      c_hidden_opm=32,
+      c_hidden_mul=128,
+      c_hidden_pair_att=32,
+      no_heads_msa=8,
+      no_heads_pair=4,
+      transition_type='swiglu',
+      transition_n=4,
+      msa_dropout=0.15,
+      pair_dropout=0.25,
+      opm_first=True,
+      fuse_projection_weights=False,
+      inf=1e8,
+      eps=1e-8,
+      last_block=(BLOCK == 3),  # OF3 drops msa_att_row/msa_transition in the last block
+  )
+  prefix = f'msa_module.blocks.{BLOCK}.'
+  sub = {k[len(prefix):]: v.detach().float()
+         for k, v in sd.items() if k.startswith(prefix)}
+  missing, unexpected = block.load_state_dict(sub, strict=False)
+  missing = [m for m in missing if 'dropout' not in m]
+  if missing or unexpected:
+    print(f'  OF3 load_state_dict: missing={missing[:6]} unexpected={unexpected[:6]}')
+  block.eval()
+  return block
+
+
+def af3_block_params(params, marker, module_name):
+  prefix = next(k.split(module_name)[0] for k in params if k.endswith(marker))
+  return {
+      scope[len(prefix):]: {n: jnp.asarray(a[BLOCK]) for n, a in entries.items()}
+      for scope, entries in params.items()
+      if scope.startswith(prefix + module_name)
+  }
+
+
+def main():
+  print(f'Loading {CKPT}  (MSA block {BLOCK})')
+  sd = conv.load_of3_checkpoint(CKPT)
+  params = conv.map_of3_to_af3(sd)
+
+  rng = np.random.default_rng(1)
+  m = rng.standard_normal((N_MSA, N_TOKENS, C_M)).astype(np.float32) * 0.5
+  z = rng.standard_normal((N_TOKENS, N_TOKENS, C_Z)).astype(np.float32) * 0.5
+  msa_mask = np.ones((N_MSA, N_TOKENS), dtype=np.float32)
+  pair_mask = np.ones((N_TOKENS, N_TOKENS), dtype=np.float32)
+
+  of3 = build_of3_block(sd)
+  with torch.no_grad():
+    of3_m, of3_z = of3(
+        m=torch.from_numpy(m.copy()),
+        z=torch.from_numpy(z.copy()),
+        msa_mask=torch.from_numpy(msa_mask.copy()),
+        pair_mask=torch.from_numpy(pair_mask.copy()),
+    )
+  of3_m, of3_z = of3_m.numpy(), of3_z.numpy()
+
+  cfg, gc = af3_config()
+
+  def fwd(msa, pair, msa_m, pair_m):
+    return modules.EvoformerIteration(cfg, gc, name='msa_stack')(
+        activations={'msa': msa, 'pair': pair},
+        masks={'msa': msa_m, 'pair': pair_m},
+    )
+
+  transformed = hk.without_apply_rng(hk.transform(fwd))
+  block_params = af3_block_params(
+      params, 'msa_stack/outer_product_mean/left_projection', 'msa_stack'
+  )
+  if os.environ.get('SABOTAGE'):
+    tgt = 'msa_stack/outer_product_mean/left_projection'
+    block_params[tgt] = {'weights': block_params[tgt]['weights'] * 1.05}
+    print('  [sabotage] scaled', tgt)
+
+  out = transformed.apply(
+      block_params, jnp.asarray(m), jnp.asarray(z),
+      jnp.asarray(msa_mask), jnp.asarray(pair_mask),
+  )
+  af3_m, af3_z = np.asarray(out['msa']), np.asarray(out['pair'])
+
+  print('\nMSA block outputs (OF3 reference vs AF3 + converted params):')
+  ok = True
+  for name, a, b in (('msa m', af3_m, of3_m), ('pair z', af3_z, of3_z)):
+    diff = np.max(np.abs(a - b))
+    scale = np.max(np.abs(b))
+    rel = diff / max(scale, 1e-9)
+    corr = np.corrcoef(a.ravel(), b.ravel())[0, 1]
+    good = rel < 2e-3
+    ok &= good
+    print(f'  {"MATCH" if good else "MISMATCH":9s} {name:<8s} max|Δ| = {diff:.3e}'
+          f'   |x|max = {scale:.3f}   rel = {rel:.2e}   r = {corr:.8f}')
+
+  print('\nRESULT:', 'block matches' if ok else 'BLOCK MISMATCH')
+  return 0 if ok else 1
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/scripts/of3_verification/compare_pair_features.py
+++ b/scripts/of3_verification/compare_pair_features.py
@@ -1,0 +1,262 @@
+"""Compare OF3 (PyTorch reference) vs AF3-with-OF3-weights on the pre-diffusion
+embeddings, using the real of3-p2-155k checkpoint.
+
+Every quantity below is an *input-boundary* embedding: each one is a linear map
+applied to features whose layout differs between the two codebases. Everything
+downstream (evoformer trunk, pairformer, diffusion conditioning) is byte-identical
+code operating on these tensors, so if all of these agree then the pair features
+entering the diffusion module agree.
+
+The same molecule / MSA is expressed twice — once in AF3's feature convention
+(via AF3's real featurizers) and once in OF3's — then pushed through the OF3
+checkpoint weights directly vs. through the converted AF3 params.
+
+Usage: python3 compare_pair_features.py [checkpoint_path]
+"""
+
+import sys
+
+import _paths
+
+_paths.add_import_paths()
+
+import numpy as np
+import torch
+from alphafold3.constants import mmcif_names
+from alphafold3.constants import residue_names
+from alphafold3.data import msa_features
+from alphafold3.model import of3_weight_converter as conv
+
+CKPT = sys.argv[1] if len(sys.argv) > 1 else _paths.checkpoint()
+
+OF3_ALPHABET = (
+    list(residue_names.PROTEIN_TYPES_WITH_UNKNOWN)
+    + ['A', 'G', 'C', 'U', 'N']
+    + ['DA', 'DG', 'DC', 'DT', 'DN']
+    + ['-']
+)
+AF3_ALPHABET = list(residue_names.POLYMER_TYPES_WITH_UNKNOWN_AND_GAP)
+N_OF3, N_AF3 = len(OF3_ALPHABET), len(AF3_ALPHABET)
+ATOM_COND = 384
+
+# ── A small mixed complex: protein + RNA + DNA + ligand ──────────────────────
+# (residue name, chain type) per token, in AF3 naming.
+PROTEIN_SEQ = 'MGKWX'          # includes Gly and unknown
+RNA_SEQ = 'AGCUN'              # every RNA base + unknown
+DNA_SEQ = 'AGCT'               # every DNA base
+TOKENS = (
+    [(residue_names.PROTEIN_COMMON_ONE_TO_THREE.get(c, 'UNK'),
+      mmcif_names.PROTEIN_CHAIN) for c in PROTEIN_SEQ]
+    + [(c if c != 'N' else 'N', mmcif_names.RNA_CHAIN) for c in RNA_SEQ]
+    + [('D' + c, mmcif_names.DNA_CHAIN) for c in DNA_SEQ]
+    + [('UNK', mmcif_names.NON_POLYMER_CHAIN)]      # ligands are UNK / OF3 'X'
+)
+N_TOKENS = len(TOKENS)
+
+# MSA: query row plus rows exercising gaps and substitutions, per chain.
+MSA_ROWS = {
+    mmcif_names.PROTEIN_CHAIN: ['MGKWX', 'M-KW-', 'AGKWC', '-----'],
+    mmcif_names.RNA_CHAIN: ['AGCUN', 'A-CU-', 'GGCCN', '-----'],
+    mmcif_names.DNA_CHAIN: ['AGCT', 'A-CT', 'GGCC', '----'],
+}
+N_MSA = 4
+
+rng = np.random.default_rng(0)
+
+
+def of3_restype_index(res_name: str, chain_type: str) -> int:
+  if chain_type in mmcif_names.LIGAND_CHAIN_TYPES:
+    return OF3_ALPHABET.index('UNK')      # OF3 'X' == AF3 UNK, index 20
+  return OF3_ALPHABET.index(res_name)
+
+
+def af3_restype_index(res_name: str, chain_type: str) -> int:
+  # Mirrors features.py: ligands -> UNK, unknown DNA -> unknown nucleic.
+  if chain_type in mmcif_names.LIGAND_CHAIN_TYPES:
+    res_name = residue_names.UNK
+  elif chain_type == mmcif_names.DNA_CHAIN and res_name == residue_names.UNK_DNA:
+    res_name = residue_names.UNK_NUCLEIC_ONE_LETTER
+  return residue_names.POLYMER_TYPES_ORDER_WITH_UNKNOWN_AND_GAP[res_name]
+
+
+def build_msa():
+  """Returns (af3_msa, of3_msa) integer arrays of shape (N_MSA, N_TOKENS)."""
+  af3 = np.full((N_MSA, N_TOKENS), AF3_ALPHABET.index('-'), dtype=np.int64)
+  of3 = np.full((N_MSA, N_TOKENS), OF3_ALPHABET.index('-'), dtype=np.int64)
+
+  col = 0
+  for chain_type, seqs in MSA_ROWS.items():
+    width = len(seqs[0])
+    # AF3 side: its real featurizer, which owns the char->class maps.
+    af3_block, _ = msa_features.extract_msa_features(
+        msa_sequences=seqs, chain_poly_type=chain_type
+    )
+    af3[:, col : col + width] = af3_block
+
+    # OF3 side: same characters, resolved against OF3's alphabet.
+    for row, seq in enumerate(seqs):
+      for offset, char in enumerate(seq):
+        if char == '-':
+          name = '-'
+        elif chain_type == mmcif_names.PROTEIN_CHAIN:
+          name = residue_names.PROTEIN_COMMON_ONE_TO_THREE.get(char, 'UNK')
+        elif chain_type == mmcif_names.RNA_CHAIN:
+          name = char if char in ('A', 'G', 'C', 'U') else 'N'
+        else:
+          name = 'D' + char if char in ('A', 'G', 'C', 'T') else 'DN'
+        of3[row, col + offset] = OF3_ALPHABET.index(name)
+    col += width
+  # The trailing ligand token stays a gap in both.
+  return af3, of3
+
+
+def one_hot(idx, num_classes):
+  out = np.zeros(idx.shape + (num_classes,), dtype=np.float32)
+  np.put_along_axis(out, idx[..., None], 1.0, axis=-1)
+  return out
+
+
+def build_features():
+  af3_msa, of3_msa = build_msa()
+
+  af3_restype = np.array(
+      [af3_restype_index(n, t) for n, t in TOKENS], dtype=np.int64
+  )
+  of3_restype = np.array(
+      [of3_restype_index(n, t) for n, t in TOKENS], dtype=np.int64
+  )
+
+  # Profiles: MSA class frequencies in each codebase's own alphabet.
+  af3_profile = one_hot(af3_msa, N_AF3).mean(axis=0)
+  of3_profile = one_hot(of3_msa, N_OF3).mean(axis=0)
+
+  # Layout-independent features, shared verbatim by both sides.
+  atom_cond = rng.standard_normal((N_TOKENS, ATOM_COND)).astype(np.float32)
+  del_mean = rng.random((N_TOKENS, 1)).astype(np.float32)
+  has_del = rng.integers(0, 2, (N_MSA, N_TOKENS, 1)).astype(np.float32)
+  del_val = rng.random((N_MSA, N_TOKENS, 1)).astype(np.float32)
+
+  af3 = {
+      'target_feat': np.concatenate(
+          [one_hot(af3_restype, N_AF3), af3_profile, del_mean, atom_cond],
+          axis=-1,
+      ),
+      # AF3's one-hot has one spare trailing class (num_types + 1).
+      'msa_feat': np.concatenate(
+          [one_hot(af3_msa, N_AF3 + 1), has_del, del_val], axis=-1
+      ),
+      'restype': one_hot(af3_restype, N_AF3),
+  }
+  of3 = {
+      's_input': np.concatenate(
+          [atom_cond, one_hot(of3_restype, N_OF3), of3_profile, del_mean],
+          axis=-1,
+      ),
+      'msa_feat': np.concatenate(
+          [one_hot(of3_msa, N_OF3), has_del, del_val], axis=-1
+      ),
+      'restype': one_hot(of3_restype, N_OF3),
+  }
+  return af3, of3
+
+
+def report(name, af3_out, of3_out, results):
+  diff = np.max(np.abs(af3_out - of3_out))
+  scale = np.max(np.abs(of3_out))
+  results.append((name, diff, scale))
+  status = 'MATCH' if diff <= 1e-5 * max(scale, 1.0) else 'MISMATCH'
+  print(f'  {status:9s} {name:<34s} max|Δ| = {diff:.3e}   (|x|max = {scale:.3f})')
+
+
+def main():
+  print(f'Loading {CKPT}')
+  sd = conv.load_of3_checkpoint(CKPT)
+  print(f'  {len(sd)} tensors')
+  print('Converting to AF3 params...')
+  params = conv.map_of3_to_af3(sd)
+  print(f'  {len(params)} param scopes\n')
+
+  def of3_w(key):
+    return sd[key].detach().float().numpy() if hasattr(sd[key], 'detach') else np.asarray(sd[key])
+
+  af3, of3 = build_features()
+  tf, s_in = af3['target_feat'], of3['s_input']
+  results = []
+
+  print('Pre-diffusion embeddings (OF3 reference vs converted AF3 params):')
+
+  # 1. Trunk single init: evoformer/single_activations
+  report(
+      'single_activations (s_init)',
+      tf @ params['diffuser/evoformer/single_activations']['weights'],
+      s_in @ of3_w('input_embedder.linear_s.weight').T,
+      results,
+  )
+
+  # 2. Trunk pair init z[i,j] — the pair features that seed the whole trunk.
+  af3_z = (
+      (tf @ params['diffuser/evoformer/left_single']['weights'])[:, None, :]
+      + (tf @ params['diffuser/evoformer/right_single']['weights'])[None, :, :]
+  )
+  of3_z = (
+      (s_in @ of3_w('input_embedder.linear_z_i.weight').T)[:, None, :]
+      + (s_in @ of3_w('input_embedder.linear_z_j.weight').T)[None, :, :]
+  )
+  report('pair init z_ij (left+right_single)', af3_z, of3_z, results)
+
+  # 3. MSA embedding — the tensor the alphabet bug corrupted.
+  report(
+      'msa_activations (m)',
+      af3['msa_feat'] @ params['diffuser/evoformer/msa_activations']['weights'],
+      of3['msa_feat'] @ of3_w('msa_module_embedder.linear_m.weight').T,
+      results,
+  )
+
+  # 4. MSA module's single-input projection.
+  report(
+      'extra_msa_target_feat',
+      tf @ params['diffuser/evoformer/extra_msa_target_feat']['weights'],
+      s_in @ of3_w('msa_module_embedder.linear_s_input.weight').T,
+      results,
+  )
+
+  # 5. Confidence head pair embedding — where PAE comes from.
+  cscope = 'diffuser/confidence_head/~_embed_features'
+  af3_cz = (
+      (tf @ params[f'{cscope}/left_target_feat_project']['weights'])[None, :, :]
+      + (tf @ params[f'{cscope}/right_target_feat_project']['weights'])[:, None, :]
+  )
+  of3_cz = (
+      (s_in @ of3_w('aux_heads.pairformer_embedding.linear_i.weight').T)[:, None, :]
+      + (s_in @ of3_w('aux_heads.pairformer_embedding.linear_j.weight').T)[None, :, :]
+  )
+  report('confidence pair embed (-> PAE)', af3_cz, of3_cz, results)
+
+  # 6. Template aatype pair embedding.
+  tscope = (
+      'diffuser/evoformer/template_embedding/single_template_embedding/'
+      'template_pair_embedding_'
+  )
+  af3_t = (
+      (af3['restype'] @ params[f'{tscope}2']['weights'])[None, :, :]
+      + (af3['restype'] @ params[f'{tscope}3']['weights'])[:, None, :]
+  )
+  tpe = 'template_embedder.template_pair_embedder'
+  of3_t = (
+      (of3['restype'] @ of3_w(f'{tpe}.aatype_linear_1.weight').T)[:, None, :]
+      + (of3['restype'] @ of3_w(f'{tpe}.aatype_linear_2.weight').T)[None, :, :]
+  )
+  report('template aatype pair embed', af3_t, of3_t, results)
+
+  print()
+  bad = [r for r in results if r[1] > 1e-5 * max(r[2], 1.0)]
+  if bad:
+    print(f'RESULT: {len(bad)}/{len(results)} MISMATCH -> '
+          + ', '.join(n for n, _, _ in bad))
+    return 1
+  print(f'RESULT: all {len(results)} pre-diffusion embeddings match OF3.')
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/scripts/of3_verification/compare_pairformer_block.py
+++ b/scripts/of3_verification/compare_pairformer_block.py
@@ -1,0 +1,170 @@
+"""Run one real trunk PairFormer block in BOTH implementations and compare.
+
+This is the check that covers the shape-invariant error classes the structural
+audit cannot see:
+  * square-matrix transposes (q/k/v/gating/output projections, tri-mul a/b/g/z)
+  * SwiGLU gate-vs-value concatenation order
+  * the of3-gated column-attention pair-bias transpose
+
+OF3 side:  openfold3.core.model.latent.pairformer.PairFormerBlock loaded from
+           `pairformer_stack.blocks.<i>.*` of the real checkpoint.
+AF3 side:  alphafold3.model.network.modules.PairFormerIteration with converted
+           params sliced out of the layer_stack at the same block index.
+
+Usage: python3 compare_pairformer_block.py [block_idx]
+"""
+
+import os
+import sys
+
+import _paths
+
+_paths.add_import_paths(require_openfold3=True)
+
+import haiku as hk
+import jax
+import jax.numpy as jnp
+import numpy as np
+import torch
+
+jax.config.update('jax_enable_x64', False)
+
+BLOCK = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+CKPT = _paths.checkpoint()
+N_TOKENS = 7
+C_S, C_Z = 384, 128
+
+_paths.no_cuda_autocast()
+
+from alphafold3.model import model_config                      # noqa: E402
+from alphafold3.model import of3_weight_converter as conv      # noqa: E402
+from alphafold3.model.network import modules                   # noqa: E402
+from openfold3.core.model.latent.pairformer import PairFormerBlock  # noqa: E402
+
+
+def af3_config():
+  """Trunk pairformer config + global config with of3_weights enabled."""
+  from alphafold3.model import model
+
+  cfg = model.Model.Config()
+  gc = cfg.global_config
+  gc.of3_weights = True
+  gc.bfloat16 = 'none'
+  gc.flash_attention_implementation = 'xla'  # no flash attention on CPU
+  return cfg.evoformer.pairformer, gc
+
+
+def build_of3_block(sd):
+  block = PairFormerBlock(
+      c_s=C_S,
+      c_z=C_Z,
+      c_hidden_pair_bias=24,
+      no_heads_pair_bias=16,
+      c_hidden_mul=128,
+      c_hidden_pair_att=32,
+      no_heads_pair=4,
+      transition_type='swiglu',
+      transition_n=4,
+      pair_dropout=0.25,
+      fuse_projection_weights=False,
+      inf=1e8,
+  )
+  prefix = f'pairformer_stack.blocks.{BLOCK}.'
+  sub = {
+      k[len(prefix):]: v.detach().float()
+      for k, v in sd.items()
+      if k.startswith(prefix)
+  }
+  missing, unexpected = block.load_state_dict(sub, strict=False)
+  # dropout/LayerNorm buffers may legitimately be absent; report anything else.
+  missing = [m for m in missing if 'dropout' not in m]
+  if missing or unexpected:
+    print(f'  OF3 load_state_dict: missing={missing[:5]} unexpected={unexpected[:5]}')
+  block.eval()
+  return block
+
+
+def af3_block_params(params):
+  """Slice block BLOCK out of the trunk pairformer layer_stack."""
+  prefix = next(
+      k.split('trunk_pairformer')[0]
+      for k in params
+      if k.endswith('trunk_pairformer/pair_attention1/act_norm')
+  )
+  out = {}
+  for scope, entries in params.items():
+    if not scope.startswith(prefix + 'trunk_pairformer'):
+      continue
+    new_scope = scope[len(prefix):]
+    out[new_scope] = {
+        name: jnp.asarray(arr[BLOCK]) for name, arr in entries.items()
+    }
+  return out
+
+
+def main():
+  print(f'Loading {CKPT}  (block {BLOCK})')
+  sd = conv.load_of3_checkpoint(CKPT)
+  params = conv.map_of3_to_af3(sd)
+
+  rng = np.random.default_rng(0)
+  z = rng.standard_normal((N_TOKENS, N_TOKENS, C_Z)).astype(np.float32) * 0.5
+  s = rng.standard_normal((N_TOKENS, C_S)).astype(np.float32) * 0.5
+  pair_mask = np.ones((N_TOKENS, N_TOKENS), dtype=np.float32)
+  seq_mask = np.ones((N_TOKENS,), dtype=np.float32)
+
+  # ── OF3 reference ──
+  of3 = build_of3_block(sd)
+  with torch.no_grad():
+    of3_s, of3_z = of3(
+        s=torch.from_numpy(s.copy()),
+        z=torch.from_numpy(z.copy()),
+        single_mask=torch.from_numpy(seq_mask.copy()),
+        pair_mask=torch.from_numpy(pair_mask.copy()),
+    )
+  of3_s = of3_s.numpy()
+  of3_z = of3_z.numpy()
+
+  # ── AF3 with converted params ──
+  cfg, gc = af3_config()
+
+  def fwd(act, pmask, single, smask):
+    return modules.PairFormerIteration(
+        cfg, gc, with_single=True, name='trunk_pairformer'
+    )(act, pmask, single, smask)
+
+  transformed = hk.without_apply_rng(hk.transform(fwd))
+  block_params = af3_block_params(params)
+  if os.environ.get('SABOTAGE'):
+    tgt = 'trunk_pairformer/pair_attention1/gating_query'
+    block_params[tgt] = {'weights': block_params[tgt]['weights'].T}
+    print('  [sabotage] transposed', tgt)
+  af3_z, af3_s = transformed.apply(
+      block_params, jnp.asarray(z), jnp.asarray(pair_mask),
+      jnp.asarray(s), jnp.asarray(seq_mask),
+  )
+  af3_z, af3_s = np.asarray(af3_z), np.asarray(af3_s)
+
+  print('\nPairFormer block outputs (OF3 reference vs AF3 + converted params):')
+  ok = True
+  for name, a, b in (('pair z', af3_z, of3_z), ('single s', af3_s, of3_s)):
+    diff = np.max(np.abs(a - b))
+    scale = np.max(np.abs(b))
+    rel = diff / max(scale, 1e-9)
+    good = rel < 2e-3
+    ok &= good
+    print(f'  {"MATCH" if good else "MISMATCH":9s} {name:<10s} '
+          f'max|Δ| = {diff:.3e}   |x|max = {scale:.3f}   rel = {rel:.2e}')
+
+  # A correlation check catches "structured but scaled" disagreement that a
+  # tolerance on max|Δ| alone might let through.
+  for name, a, b in (('pair z', af3_z, of3_z), ('single s', af3_s, of3_s)):
+    corr = np.corrcoef(a.ravel(), b.ravel())[0, 1]
+    print(f'            {name:<10s} pearson r = {corr:.8f}')
+
+  print('\nRESULT:', 'block matches' if ok else 'BLOCK MISMATCH')
+  return 0 if ok else 1
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/scripts/of3_verification/compare_template_block.py
+++ b/scripts/of3_verification/compare_template_block.py
@@ -1,0 +1,112 @@
+"""Compare a template pair-stack block (pair-only PairFormerIteration, c_z=64).
+
+The template stack is the one place _pairblock_params is called with a different
+tri_mul_hidden argument and with_single=False, so it gets its own check.
+
+Usage: python3 compare_template_block.py [block_idx]   SABOTAGE=1 to self-test
+"""
+
+import os
+import sys
+
+import _paths
+
+_paths.add_import_paths(require_openfold3=True)
+
+import haiku as hk
+import jax.numpy as jnp
+import numpy as np
+import torch
+
+_paths.no_cuda_autocast()
+
+from alphafold3.model import of3_weight_converter as conv   # noqa: E402
+from alphafold3.model.network import modules                # noqa: E402
+from openfold3.core.model.latent.base_blocks import PairBlock  # noqa: E402
+
+BLOCK = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+CKPT = _paths.checkpoint()
+N_TOKENS, C_Z = 7, 64
+
+
+def main():
+  print(f'Loading {CKPT}  (template block {BLOCK})')
+  sd = conv.load_of3_checkpoint(CKPT)
+  params = conv.map_of3_to_af3(sd)
+
+  rng = np.random.default_rng(3)
+  z = rng.standard_normal((N_TOKENS, N_TOKENS, C_Z)).astype(np.float32) * 0.5
+  pair_mask = np.ones((N_TOKENS, N_TOKENS), dtype=np.float32)
+
+  # ── OF3 reference: the template pair stack block is a bare PairBlock ──
+  of3 = PairBlock(
+      c_z=C_Z,
+      c_hidden_mul=64,
+      c_hidden_pair_att=16,
+      no_heads_pair=4,
+      transition_type='swiglu',
+      transition_n=2,
+      pair_dropout=0.25,
+      fuse_projection_weights=False,
+      inf=1e8,
+  )
+  prefix = f'template_embedder.template_pair_stack.blocks.{BLOCK}.'
+  sub = {k[len(prefix):]: v.detach().float()
+         for k, v in sd.items() if k.startswith(prefix)}
+  missing, unexpected = of3.load_state_dict(sub, strict=False)
+  missing = [m for m in missing if 'dropout' not in m]
+  if missing or unexpected:
+    print(f'  OF3 load: missing={missing[:6]} unexpected={unexpected[:6]}')
+  of3.eval()
+  with torch.no_grad():
+    of3_z = of3(
+        z=torch.from_numpy(z.copy()),
+        pair_mask=torch.from_numpy(pair_mask.copy()),
+    ).numpy()
+
+  # ── AF3 with converted params ──
+  from alphafold3.model import model
+  from alphafold3.model.network import template_modules
+
+  gc = model.Model.Config().global_config
+  gc.of3_weights = True
+  gc.bfloat16 = 'none'
+  gc.flash_attention_implementation = 'xla'
+  cfg = template_modules.TemplateEmbedding.Config().template_stack
+
+  def fwd(act, pmask):
+    return modules.PairFormerIteration(
+        cfg, gc, name='template_embedding_iteration'
+    )(act, pmask)
+
+  transformed = hk.without_apply_rng(hk.transform(fwd))
+  name = 'template_embedding_iteration'
+  prefix_scope = next(k.split(name)[0] for k in params if name in k)
+  block_params = {
+      k[len(prefix_scope):]: {n: jnp.asarray(v[BLOCK]) for n, v in e.items()}
+      for k, e in params.items()
+      if k.startswith(prefix_scope + name)
+  }
+  if os.environ.get('SABOTAGE'):
+    tgt = f'{name}/pair_attention2/output_projection'
+    block_params[tgt] = {'weights': block_params[tgt]['weights'].T}
+    print('  [sabotage] transposed', tgt)
+
+  af3_z = np.asarray(transformed.apply(
+      block_params, jnp.asarray(z), jnp.asarray(pair_mask)
+  ))
+
+  diff = np.max(np.abs(af3_z - of3_z))
+  scale = np.max(np.abs(of3_z))
+  rel = diff / max(scale, 1e-9)
+  corr = np.corrcoef(af3_z.ravel(), of3_z.ravel())[0, 1]
+  good = rel < 2e-3
+  print('\nTemplate pair-stack block output:')
+  print(f'  {"MATCH" if good else "MISMATCH":9s} pair z  max|Δ| = {diff:.3e}'
+        f'   |x|max = {scale:.3f}   rel = {rel:.2e}   r = {corr:.8f}')
+  print('\nRESULT:', 'matches' if good else 'MISMATCH')
+  return 0 if good else 1
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/scripts/of3_verification/dump_param_digest.py
+++ b/scripts/of3_verification/dump_param_digest.py
@@ -1,0 +1,36 @@
+"""Dump {scope/name: [shape, md5]} for every converted AF3 param.
+
+Used to diff the converted parameter tree before vs. after the fixes: shapes
+must be identical (so nothing downstream can fail to load) and only the
+deliberately-changed arrays may differ in content.
+"""
+
+import hashlib
+import json
+import sys
+
+import _paths
+
+_paths.add_import_paths()
+
+import numpy as np
+from alphafold3.model import of3_weight_converter as conv
+
+CKPT = _paths.checkpoint()
+out_path = sys.argv[1]
+
+sd = conv.load_of3_checkpoint(CKPT)
+params = conv.map_of3_to_af3(sd)
+
+digest = {}
+for scope, entries in params.items():
+  for name, arr in entries.items():
+    arr = np.ascontiguousarray(np.asarray(arr))
+    digest[f'{scope}/{name}'] = [
+        list(arr.shape),
+        hashlib.md5(arr.tobytes()).hexdigest(),
+    ]
+
+with open(out_path, 'w') as f:
+  json.dump(digest, f, indent=0, sort_keys=True)
+print(f'{len(digest)} arrays -> {out_path}')

--- a/src/alphafold3/model/network/diffusion_head.py
+++ b/src/alphafold3/model/network/diffusion_head.py
@@ -22,6 +22,7 @@
 from collections.abc import Callable
 
 from alphafold3.common import base_config
+from alphafold3.constants import residue_names
 from alphafold3.model import feat_batch
 from alphafold3.model import model_config
 from alphafold3.model.components import haiku_modules as hm
@@ -175,6 +176,30 @@ class DiffusionHead(hk.Module):
 
     target_feat = embeddings['target_feat']
     features_1d = jnp.concatenate([single_embedding, target_feat], axis=-1)
+    if self.global_config.of3_weights:
+      # OF3's restype and profile blocks carry 32 classes; AF3's carry 31 (AF3
+      # folds unknown DNA into the shared unknown-nucleic class). Everywhere
+      # else the extra class can simply be dropped from the weights, because a
+      # zero input column contributes nothing to a bare Linear. Here it cannot:
+      # the LayerNorm below maps a zero input to -mean/std, so OF3 always adds a
+      # trained contribution through those two columns and normalises over 833
+      # channels instead of 831. Re-insert them as zeros to match exactly; the
+      # weight converter emits its rows in this same order.
+      num_af3_restypes = residue_names.POLYMER_TYPES_NUM_WITH_UNKNOWN_AND_GAP
+      pad = jnp.zeros_like(features_1d[..., :1])
+      single_channels = single_embedding.shape[-1]
+      aatype_end = single_channels + num_af3_restypes
+      profile_end = aatype_end + num_af3_restypes
+      features_1d = jnp.concatenate(
+          [
+              features_1d[..., :aatype_end],
+              pad,  # OF3 aatype UNK_DNA
+              features_1d[..., aatype_end:profile_end],
+              pad,  # OF3 profile UNK_DNA
+              features_1d[..., profile_end:],
+          ],
+          axis=-1,
+      )
     single_cond = hm.LayerNorm(
         use_fast_variance=False,
         create_offset=False,

--- a/src/alphafold3/model/of3_weight_converter.py
+++ b/src/alphafold3/model/of3_weight_converter.py
@@ -37,6 +37,10 @@ _AF3_TO_OF3_AATYPE = np.array(
 # activated under AF3 featurization).
 _AF3_TO_OF3_MSA = np.concatenate([_AF3_TO_OF3_AATYPE, [30]]).astype(np.int32)
 
+# OF3's unknown-DNA class ('DN'), the one class AF3's 31-way alphabet has no slot
+# for (AF3 folds unknown DNA into the shared unknown-nucleic class 'N').
+_OF3_UNK_DNA_AATYPE = 30
+
 
 def _pad_element_weights(w: np.ndarray) -> np.ndarray:
     """Pad OF3 element embedding weights from 119 rows to 128 (AF3 uses 128 classes).
@@ -88,18 +92,31 @@ def _reorder_features_1d(arr: np.ndarray, c_single: int = 384) -> np.ndarray:
     """Reorder OF3 features_1d (single_emb + target_feat) along axis 0 to AF3 layout.
 
     OF3 layout: [single(c_single), atom_cross_att(384), OF3_aatype(32), OF3_profile(32), del_mean(1)]
-    AF3 layout: [single(c_single), AF3_aatype(31),      AF3_profile(31), del_mean(1),    atom_cross_att(384)]
+    AF3 layout: [single(c_single), AF3_aatype(31), UNK_DNA(1), AF3_profile(31), UNK_DNA(1),
+                 del_mean(1), atom_cross_att(384)]
+
+    Unlike every other residue-indexed matrix, the two aatype classes AF3 lacks
+    (OF3's unknown-DNA slot in restype and in profile) may NOT be dropped here:
+    this block feeds `single_cond_initial_norm`, a LayerNorm, which turns a zero
+    input into -mean/std. OF3 therefore always contributes those two columns
+    through their trained weights, and the normalisation statistics run over 833
+    channels rather than 831. Both effects are reproduced by keeping the columns
+    (diffusion_head inserts matching zero columns when of3_weights is set);
+    dropping them costs ~1.6e-3 relative error in the single conditioning.
 
     Works for 1-D (LayerNorm scale, shape c_single+449) and 2-D (Linear weights,
     shape (c_single+449, c_out)) arrays — reorders along axis 0.
     """
     remap = _AF3_TO_OF3_AATYPE
+    unk_dna = _OF3_UNK_DNA_AATYPE
     return np.concatenate([
         arr[0:c_single],
-        arr[c_single + 384 + remap],         # aatype rows
-        arr[c_single + 416 + remap],         # profile rows
-        arr[c_single + 448: c_single + 449], # del_mean
-        arr[c_single: c_single + 384],       # atom_cross_att
+        arr[c_single + 384 + remap],                        # aatype rows
+        arr[c_single + 384 + unk_dna: c_single + 385 + unk_dna],  # aatype UNK_DNA
+        arr[c_single + 416 + remap],                        # profile rows
+        arr[c_single + 416 + unk_dna: c_single + 417 + unk_dna],  # profile UNK_DNA
+        arr[c_single + 448: c_single + 449],                # del_mean
+        arr[c_single: c_single + 384],                       # atom_cross_att
     ], axis=0)
 
 
@@ -283,8 +300,7 @@ def convert_single_attention(sd: dict, prefix: str, H: int, D: int) -> dict[str,
 # ─── Block composers ──────────────────────────────────────────────────────────
 
 def _pairblock_params(sd: dict, prefix: str,
-                      pair_H: int, pair_D: int,
-                      tri_mul_hidden: int) -> dict[str, np.ndarray]:
+                      pair_H: int, pair_D: int) -> dict[str, np.ndarray]:
     d = {}
     for tag, of3_name, outgoing in [
         ('triangle_multiplication_outgoing', 'tri_mul_out', True),
@@ -303,11 +319,10 @@ def _pairblock_params(sd: dict, prefix: str,
 
 def pairformer_block_params(sd: dict, block_idx: int,
                              pair_H: int = 4, pair_D: int = 32,
-                             single_H: int = 16, single_D: int = 24,
-                             tri_mul_hidden: int = 128) -> dict[str, np.ndarray]:
+                             single_H: int = 16, single_D: int = 24) -> dict[str, np.ndarray]:
     prefix = f'pairformer_stack.blocks.{block_idx}'
     d = {}
-    for k, v in _pairblock_params(sd, f'{prefix}.pair_stack', pair_H, pair_D, tri_mul_hidden).items():
+    for k, v in _pairblock_params(sd, f'{prefix}.pair_stack', pair_H, pair_D).items():
         d[k] = v
     for k, v in convert_single_attention(sd, f'{prefix}.attn_pair_bias', single_H, single_D).items():
         d[k] = v
@@ -333,7 +348,7 @@ def msa_block_params(sd: dict, block_idx: int,
             d[f'outer_product_mean:{k[len("__top__/"):]}'] = v
         else:
             d[f'outer_product_mean/{k}'] = v
-    for k, v in _pairblock_params(sd, f'{prefix}.pair_stack', pair_H, pair_D, 128).items():
+    for k, v in _pairblock_params(sd, f'{prefix}.pair_stack', pair_H, pair_D).items():
         d[k] = v
     return d
 
@@ -431,7 +446,7 @@ def map_confidence_head(sd: dict, params: dict,
         def _block_fn(block_idx):
             prefix = f'aux_heads.pairformer_embedding.pairformer_stack.blocks.{block_idx}'
             d = {}
-            for k, v in _pairblock_params(sd, f'{prefix}.pair_stack', pair_H, pair_D, c_z).items():
+            for k, v in _pairblock_params(sd, f'{prefix}.pair_stack', pair_H, pair_D).items():
                 d[k] = v
             for k, v in convert_single_attention(sd, f'{prefix}.attn_pair_bias', single_H, single_D).items():
                 d[k] = v
@@ -659,7 +674,7 @@ def map_template_embedder(sd: dict, params: dict, *,
     _set(params, f'{scope_ste}/output_layer_norm', 'scale',  _get(sd, f'{tps}.layer_norm.weight'))
     _set(params, f'{scope_ste}/output_layer_norm', 'offset', _get(sd, f'{tps}.layer_norm.bias'))
     stacked = _stack_blocks(
-        lambda block_idx: _pairblock_params(sd, f'{tps}.blocks.{block_idx}', templ_H, templ_D, 0),
+        lambda block_idx: _pairblock_params(sd, f'{tps}.blocks.{block_idx}', templ_H, templ_D),
         n_templ_blocks)
     _populate_scope(params, f'{scope_ste}/__layer_stack_no_per_layer/template_embedding_iteration', stacked)
     _set(params, f'{scope_te}/output_linear', 'weights', _t(_get(sd, f'{te}.linear_t.weight')))

--- a/src/alphafold3/model/of3_weight_converter_test.py
+++ b/src/alphafold3/model/of3_weight_converter_test.py
@@ -1,0 +1,559 @@
+# Copyright 2024 DeepMind Technologies Limited
+#
+# AlphaFold 3 source code is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# To request access to the AlphaFold 3 model parameters, follow the process set
+# out at https://github.com/google-deepmind/alphafold3. You may only use these
+# if received directly from Google. Use is subject to terms of use available at
+# https://github.com/google-deepmind/alphafold3/blob/main/WEIGHTS_TERMS_OF_USE.md
+
+"""Tests the OpenFold3 → AlphaFold3 residue alphabet remapping.
+
+OF3 and AF3 order the residue classes differently, so every weight matrix whose
+input rows are indexed by residue type has to be permuted during conversion.
+Protein and DNA indices happen to coincide, which makes a missing permutation
+easy to miss: the shapes match and only RNA bases and gaps come out wrong.
+
+The tests feed the converter a *marker* state dict — every weight row holds its
+own OF3 row index — so the converted parameters read back as "which OF3 row did
+AF3 class c end up pulling from". That is checked against AF3's real featurizers
+(`msa_features`, `residue_names`), which makes these behavioural tests rather
+than a restatement of the converter's internal tables.
+
+Neither the openfold3 package nor an OF3 checkpoint is required. The OF3
+alphabet is transcribed from `openfold3/core/data/resources/residues.py`
+(`STANDARD_RESIDUES_WITH_GAP_3`). `CheckpointLayoutTest` optionally validates
+the hardcoded block offsets against a real checkpoint when one is available.
+"""
+
+import inspect
+import os
+import re
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from alphafold3.constants import mmcif_names
+from alphafold3.constants import residue_names
+from alphafold3.data import msa_features
+from alphafold3.model import data_constants
+from alphafold3.model import of3_weight_converter as converter
+import numpy as np
+
+
+# openfold3.core.data.resources.residues.STANDARD_RESIDUES_WITH_GAP_3, with
+# OF3's 'GAP' spelled the AF3 way ('-') so the two lists are comparable.
+_OF3_ALPHABET = (
+    'ALA', 'ARG', 'ASN', 'ASP', 'CYS', 'GLN', 'GLU', 'GLY', 'HIS', 'ILE',
+    'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL',
+    'UNK',
+    'A', 'G', 'C', 'U', 'N',
+    'DA', 'DG', 'DC', 'DT', 'DN',
+    '-',
+)  # pyformat: disable
+
+_AF3_ALPHABET = residue_names.POLYMER_TYPES_WITH_UNKNOWN_AND_GAP
+
+_NUM_OF3_RESTYPES = len(_OF3_ALPHABET)  # 32
+_NUM_AF3_RESTYPES = len(_AF3_ALPHABET)  # 31
+
+# Block layout of OF3's msa_feat / s_input, from
+# openfold3.core.model.feature_embedders.input_embedders:
+#   s_input  = [atom_cond(384), restype(32), profile(32), deletion_mean(1)]
+#   msa_feat = [restype(32), has_deletion(1), deletion_value(1)]
+_ATOM_COND_DIM = 384
+_S_INPUT_DIM = _ATOM_COND_DIM + 2 * _NUM_OF3_RESTYPES + 1  # 449
+_MSA_FEAT_DIM = _NUM_OF3_RESTYPES + 2  # 34
+_C_SINGLE = 384
+
+# AF3's equivalent target_feat, from featurization.create_target_feat:
+#   [restype(31), profile(31), deletion_mean(1), atom_cond(384)]
+_AF3_TARGET_FEAT_DIM = 2 * _NUM_AF3_RESTYPES + 1 + _ATOM_COND_DIM  # 447
+
+_CHECKPOINT_ENV_VAR = 'OF3_CHECKPOINT'
+# Resolved relative to the repository root (this file lives in src/alphafold3/model).
+_CHECKPOINT_FALLBACKS = ('../af3_of3/weights/of3-p2-155k.pt',)
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..')
+)
+
+
+def _marker_weight(num_in: int, c_out: int = 3) -> np.ndarray:
+  """PyTorch-layout (out, in) weight whose transpose has row i filled with i."""
+  return np.tile(np.arange(num_in, dtype=np.float32)[None, :], (c_out, 1))
+
+
+def _marker_state_dict(c_out: int = 3) -> dict[str, np.ndarray]:
+  """Minimal OF3 state dict covering every residue-indexed weight matrix."""
+  return {
+      # Required unconditionally by map_evoformer_input_embeddings.
+      'layer_norm_z.weight': np.zeros(c_out, dtype=np.float32),
+      'layer_norm_z.bias': np.zeros(c_out, dtype=np.float32),
+      'linear_z.weight': np.zeros((c_out, c_out), dtype=np.float32),
+      'layer_norm_s.weight': np.zeros(c_out, dtype=np.float32),
+      'layer_norm_s.bias': np.zeros(c_out, dtype=np.float32),
+      'linear_s.weight': np.zeros((c_out, c_out), dtype=np.float32),
+      # The residue-indexed matrices under test.
+      'msa_module_embedder.linear_m.weight': _marker_weight(
+          _MSA_FEAT_DIM, c_out
+      ),
+      'msa_module_embedder.linear_s_input.weight': _marker_weight(
+          _S_INPUT_DIM, c_out
+      ),
+      'input_embedder.linear_s.weight': _marker_weight(_S_INPUT_DIM, c_out),
+      'input_embedder.linear_z_i.weight': _marker_weight(_S_INPUT_DIM, c_out),
+      'input_embedder.linear_z_j.weight': _marker_weight(_S_INPUT_DIM, c_out),
+  }
+
+
+def _template_aatype_mapping_statement() -> str:
+  """The `for idx, attr in [...]` line mapping OF3 aatype linears, plus its body.
+
+  Used by the two template checks: driving map_template_embedder end to end
+  would require a fully-populated fake template pair stack.
+  """
+  lines = inspect.getsource(converter.map_template_embedder).splitlines()
+  idx = next(
+      i
+      for i, line in enumerate(lines)
+      if 'aatype_linear_1' in line and line.lstrip().startswith('for ')
+  )
+  return '\n'.join(lines[idx : idx + 3])
+
+
+def _converted_source_rows(param_scope: str) -> np.ndarray:
+  """Runs the converter on marker weights; returns OF3 source row per AF3 row."""
+  params = {}
+  converter.map_evoformer_input_embeddings(_marker_state_dict(), params)
+  return params[param_scope]['weights'][:, 0]
+
+
+class AlphabetOrderingTest(parameterized.TestCase):
+  """The two alphabets differ exactly where we think they do."""
+
+  def test_alphabet_sizes(self):
+    self.assertLen(_OF3_ALPHABET, 32)
+    self.assertLen(_AF3_ALPHABET, 31)
+
+  def test_nucleic_classes_disagree_between_codebases(self):
+    """RNA is offset by one; GAP and N move entirely."""
+    af3 = {name: i for i, name in enumerate(_AF3_ALPHABET)}
+    of3 = {name: i for i, name in enumerate(_OF3_ALPHABET)}
+    for name in ('A', 'G', 'C', 'U', 'N', '-'):
+      with self.subTest(residue=name):
+        self.assertNotEqual(af3[name], of3[name])
+
+  def test_protein_and_dna_classes_agree_between_codebases(self):
+    """Why a missing permutation is silent for protein and DNA."""
+    af3 = {name: i for i, name in enumerate(_AF3_ALPHABET)}
+    of3 = {name: i for i, name in enumerate(_OF3_ALPHABET)}
+    for name in residue_names.PROTEIN_TYPES_WITH_UNKNOWN + (
+        'DA',
+        'DG',
+        'DC',
+        'DT',
+    ):
+      with self.subTest(residue=name):
+        self.assertEqual(af3[name], of3[name])
+
+
+class TargetFeatRemapTest(parameterized.TestCase):
+  """restype/profile rows of target_feat must name the same residue in OF3."""
+
+  @parameterized.named_parameters(
+      ('single_activations', 'diffuser/evoformer/single_activations'),
+      ('left_single', 'diffuser/evoformer/left_single'),
+      ('right_single', 'diffuser/evoformer/right_single'),
+      ('extra_msa_target_feat', 'diffuser/evoformer/extra_msa_target_feat'),
+  )
+  def test_restype_and_profile_rows_are_remapped(self, scope):
+    rows = _converted_source_rows(scope)
+    self.assertLen(rows, _AF3_TARGET_FEAT_DIM)
+
+    restype_block = rows[:_NUM_AF3_RESTYPES]
+    profile_block = rows[_NUM_AF3_RESTYPES : 2 * _NUM_AF3_RESTYPES]
+    for af3_idx, af3_name in enumerate(_AF3_ALPHABET):
+      with self.subTest(residue=af3_name):
+        restype_src = int(restype_block[af3_idx]) - _ATOM_COND_DIM
+        profile_src = (
+            int(profile_block[af3_idx]) - _ATOM_COND_DIM - _NUM_OF3_RESTYPES
+        )
+        self.assertEqual(_OF3_ALPHABET[restype_src], af3_name)
+        self.assertEqual(_OF3_ALPHABET[profile_src], af3_name)
+
+  def test_non_residue_blocks_are_reordered_but_not_permuted(self):
+    rows = _converted_source_rows('diffuser/evoformer/single_activations')
+    # deletion_mean is the last OF3 row; atom conditioning is OF3 rows 0-383.
+    self.assertEqual(rows[2 * _NUM_AF3_RESTYPES], _S_INPUT_DIM - 1)
+    np.testing.assert_array_equal(
+        rows[2 * _NUM_AF3_RESTYPES + 1 :], np.arange(_ATOM_COND_DIM)
+    )
+
+
+class MsaFeatRemapTest(parameterized.TestCase):
+  """AF3-featurized MSA columns must land on the OF3 row for that residue.
+
+  This is the regression the original bug would fail: linear_m was transposed
+  but never permuted, so gaps read OF3's RNA-adenine row and RNA bases read one
+  row too high (A→G, G→C, C→U, U→N).
+  """
+
+  def setUp(self):
+    super().setUp()
+    self._rows = _converted_source_rows('diffuser/evoformer/msa_activations')
+
+  def _of3_name_for_msa_index(self, af3_msa_index: int) -> str:
+    return _OF3_ALPHABET[int(self._rows[af3_msa_index])]
+
+  def _of3_name_for_char(self, char: str, chain_poly_type: str) -> str:
+    msa, _ = msa_features.extract_msa_features(
+        msa_sequences=[char], chain_poly_type=chain_poly_type
+    )
+    return self._of3_name_for_msa_index(msa[0, 0])
+
+  def test_msa_feat_width_is_unchanged(self):
+    self.assertLen(self._rows, _MSA_FEAT_DIM)
+
+  def test_deletion_features_are_not_permuted(self):
+    """has_deletion / deletion_value are positional in both layouts."""
+    np.testing.assert_array_equal(
+        self._rows[-2:], [_NUM_OF3_RESTYPES, _NUM_OF3_RESTYPES + 1]
+    )
+
+  @parameterized.named_parameters(
+      ('protein', mmcif_names.PROTEIN_CHAIN),
+      ('rna', mmcif_names.RNA_CHAIN),
+      ('dna', mmcif_names.DNA_CHAIN),
+  )
+  def test_gap_maps_to_of3_gap(self, chain_poly_type):
+    self.assertEqual(self._of3_name_for_char('-', chain_poly_type), '-')
+
+  def test_msa_padding_value_maps_to_of3_gap(self):
+    """AF3 pads MSA rows with the gap class; padded rows must embed as gaps."""
+    self.assertEqual(
+        self._of3_name_for_msa_index(data_constants.MSA_GAP_IDX), '-'
+    )
+
+  @parameterized.parameters(('A', 'A'), ('G', 'G'), ('C', 'C'), ('U', 'U'))
+  def test_rna_bases_map_to_of3_rna_bases(self, char, expected):
+    self.assertEqual(
+        self._of3_name_for_char(char, mmcif_names.RNA_CHAIN), expected
+    )
+
+  @parameterized.parameters(('A', 'DA'), ('G', 'DG'), ('C', 'DC'), ('T', 'DT'))
+  def test_dna_bases_map_to_of3_dna_bases(self, char, expected):
+    self.assertEqual(
+        self._of3_name_for_char(char, mmcif_names.DNA_CHAIN), expected
+    )
+
+  @parameterized.named_parameters(
+      ('rna', mmcif_names.RNA_CHAIN),
+      # AF3 has a single unknown-nucleic MSA class, so unknown DNA also lands on
+      # OF3's RNA 'N' rather than 'DN'.
+      ('dna', mmcif_names.DNA_CHAIN),
+  )
+  def test_unknown_nucleic_maps_to_of3_unknown_nucleic(self, chain_poly_type):
+    self.assertEqual(self._of3_name_for_char('X', chain_poly_type), 'N')
+
+  def test_protein_residues_map_to_of3_protein_residues(self):
+    for one_letter, three_letter in (
+        residue_names.PROTEIN_COMMON_ONE_TO_THREE.items()
+    ):
+      with self.subTest(residue=one_letter):
+        self.assertEqual(
+            self._of3_name_for_char(one_letter, mmcif_names.PROTEIN_CHAIN),
+            three_letter,
+        )
+
+  def test_unknown_protein_residue_maps_to_of3_unk(self):
+    self.assertEqual(
+        self._of3_name_for_char('X', mmcif_names.PROTEIN_CHAIN), 'UNK'
+    )
+
+  def test_spare_af3_class_does_not_shadow_a_used_of3_row(self):
+    """AF3's MSA one-hot has one class its featurizer never emits."""
+    used = set()
+    for char_map in (
+        msa_features._PROTEIN_TO_ID,  # pylint: disable=protected-access
+        msa_features._RNA_TO_ID,  # pylint: disable=protected-access
+        msa_features._DNA_TO_ID,  # pylint: disable=protected-access
+    ):
+      used.update(char_map.values())
+    spare = [i for i in range(_MSA_FEAT_DIM - 2) if i not in used]
+    self.assertEqual(spare, [_NUM_AF3_RESTYPES])
+    self.assertNotIn(
+        int(self._rows[_NUM_AF3_RESTYPES]),
+        [int(self._rows[i]) for i in sorted(used)],
+    )
+
+
+class OtherResidueIndexedWeightsTest(parameterized.TestCase):
+  """The remaining residue-indexed matrices, checked the same way."""
+
+  def test_template_aatype_reorder_names_the_same_residue(self):
+    """Templates one-hot the aatype directly, so 32 OF3 rows → 31 AF3 rows."""
+    rows = converter._reorder_aatype_weights(  # pylint: disable=protected-access
+        _marker_weight(_NUM_OF3_RESTYPES).T
+    )[:, 0]
+
+    self.assertLen(rows, _NUM_AF3_RESTYPES)
+    for af3_idx, af3_name in enumerate(_AF3_ALPHABET):
+      with self.subTest(residue=af3_name):
+        self.assertEqual(_OF3_ALPHABET[int(rows[af3_idx])], af3_name)
+
+  def test_template_aatype_call_site_uses_the_reorder(self):
+    """Call-site guard: exercising map_template_embedder end to end would need
+    a full fake template pair stack, so assert the wiring statically instead."""
+    statement = _template_aatype_mapping_statement()
+    self.assertIn('_reorder_aatype_weights', statement)
+
+  def test_confidence_head_target_feat_weights_are_remapped(self):
+    params = {}
+    converter.map_confidence_head(
+        {
+            'aux_heads.pairformer_embedding.linear_i.weight': _marker_weight(
+                _S_INPUT_DIM
+            ),
+            'aux_heads.pairformer_embedding.linear_j.weight': _marker_weight(
+                _S_INPUT_DIM
+            ),
+        },
+        params,
+    )
+
+    for name in ('left_target_feat_project', 'right_target_feat_project'):
+      rows = params[f'diffuser/confidence_head/~_embed_features/{name}'][
+          'weights'
+      ][:, 0]
+      self.assertLen(rows, _AF3_TARGET_FEAT_DIM)
+      for af3_idx, af3_name in enumerate(_AF3_ALPHABET):
+        with self.subTest(param=name, residue=af3_name):
+          src = int(rows[af3_idx]) - _ATOM_COND_DIM
+          self.assertEqual(_OF3_ALPHABET[src], af3_name)
+
+  def test_diffusion_conditioning_features_1d_is_remapped(self):
+    """features_1d = [single(384), target_feat(449)] in OF3 order."""
+    rows = converter._reorder_features_1d(  # pylint: disable=protected-access
+        np.arange(_C_SINGLE + _S_INPUT_DIM, dtype=np.float32),
+        c_single=_C_SINGLE,
+    )
+    # 833, not 831: this block feeds a LayerNorm, so the two classes AF3 lacks
+    # must be kept rather than dropped (see the next test).
+    self.assertLen(rows, _C_SINGLE + _S_INPUT_DIM)
+    # The single embedding passes through untouched...
+    np.testing.assert_array_equal(rows[:_C_SINGLE], np.arange(_C_SINGLE))
+    # ...and the restype block is permuted.
+    for af3_idx, af3_name in enumerate(_AF3_ALPHABET):
+      with self.subTest(residue=af3_name):
+        src = int(rows[_C_SINGLE + af3_idx]) - _C_SINGLE - _ATOM_COND_DIM
+        self.assertEqual(_OF3_ALPHABET[src], af3_name)
+
+  def test_features_1d_keeps_the_class_af3_lacks(self):
+    """The unknown-DNA restype and profile columns must NOT be dropped here.
+
+    `single_cond_initial_norm` is a LayerNorm, so a zero input column still
+    contributes -mean/std through its trained weights, and the normalisation
+    statistics depend on the channel count. Dropping the two columns AF3 has no
+    slot for cost ~1.6e-3 relative error in the diffusion single conditioning.
+    """
+    rows = converter._reorder_features_1d(  # pylint: disable=protected-access
+        np.arange(_C_SINGLE + _S_INPUT_DIM, dtype=np.float32),
+        c_single=_C_SINGLE,
+    ).astype(int)
+
+    unk_dna = _OF3_ALPHABET.index('DN')
+    restype_base = _C_SINGLE + _ATOM_COND_DIM
+    profile_base = restype_base + _NUM_OF3_RESTYPES
+    # Immediately after each permuted 31-class block sits the kept extra class.
+    self.assertEqual(
+        rows[_C_SINGLE + _NUM_AF3_RESTYPES], restype_base + unk_dna
+    )
+    self.assertEqual(
+        rows[_C_SINGLE + 2 * _NUM_AF3_RESTYPES + 1], profile_base + unk_dna
+    )
+    # Every OF3 restype/profile channel is therefore represented exactly once.
+    kept = set(rows.tolist())
+    for base in (restype_base, profile_base):
+      for offset in range(_NUM_OF3_RESTYPES):
+        with self.subTest(channel=base + offset):
+          self.assertIn(base + offset, kept)
+
+
+class PairEmbeddingIndexConventionTest(parameterized.TestCase):
+  """Row (i) vs column (j) projections must not be swapped.
+
+  AF3's own naming is inconsistent between its two pair-embedding sites, so
+  linear_i/linear_j cannot be mapped to left/right by name:
+
+    evoformer._seq_pair_embedding:    left[:, None] + right[None]
+        -> out[i, j] = left[i] + right[j]
+    confidence_head._embed_features:  left(tf) + right(tf)[:, None]
+        -> out[i, j] = left[j] + right[i]
+
+  OF3 uses the evoformer convention in both places, so the confidence head has
+  to cross them. A swap here transposes the confidence pair embedding, which
+  shows up in PAE: it is the only asymmetric confidence output (PDE is
+  explicitly symmetrized, pLDDT and experimentally-resolved come from the
+  single representation).
+  """
+
+  # Each row of s is a distinct one-hot, so out[i, j] identifies which token
+  # index each projection was applied to.
+  _NUM_TOKENS = 3
+
+  def _single_input(self) -> np.ndarray:
+    """Token features occupying only the atom-conditioning block.
+
+    Keeps the residue-alphabet permutation out of this test.
+    """
+    s = np.zeros((self._NUM_TOKENS, _S_INPUT_DIM), dtype=np.float32)
+    for token in range(self._NUM_TOKENS):
+      s[token, token] = 1.0
+    return s
+
+  def _af3_target_feat(self, s: np.ndarray) -> np.ndarray:
+    """The same features in AF3's target_feat block order."""
+    tf = np.zeros((self._NUM_TOKENS, _AF3_TARGET_FEAT_DIM), dtype=np.float32)
+    atom_cond_start = 2 * _NUM_AF3_RESTYPES + 1
+    tf[:, atom_cond_start:] = s[:, :_ATOM_COND_DIM]
+    return tf
+
+  def _of3_weights(self, c_out: int = 2) -> tuple[np.ndarray, np.ndarray]:
+    """Distinguishable (out, in) weights for the i and j projections."""
+    w_i = np.zeros((c_out, _S_INPUT_DIM), dtype=np.float32)
+    w_j = np.zeros((c_out, _S_INPUT_DIM), dtype=np.float32)
+    w_i[0, :] = 1.0  # channel 0 reports the token index it saw...
+    w_j[1, :] = 1.0  # ...channel 1 likewise, for the other projection.
+    w_i[0, :] *= np.arange(_S_INPUT_DIM) + 1
+    w_j[1, :] *= np.arange(_S_INPUT_DIM) + 1
+    return w_i, w_j
+
+  def test_confidence_head_crosses_i_and_j(self):
+    s = self._single_input()
+    w_i, w_j = self._of3_weights()
+
+    # OF3: zij = zij + linear_i(s.unsqueeze(-2)) + linear_j(s.unsqueeze(-3))
+    of3 = (s @ w_i.T)[:, None, :] + (s @ w_j.T)[None, :, :]
+
+    params = {}
+    converter.map_confidence_head({
+        'aux_heads.pairformer_embedding.linear_i.weight': w_i,
+        'aux_heads.pairformer_embedding.linear_j.weight': w_j,
+    }, params)
+    scope = 'diffuser/confidence_head/~_embed_features'
+    left = params[f'{scope}/left_target_feat_project']['weights']
+    right = params[f'{scope}/right_target_feat_project']['weights']
+
+    # AF3: out = left(tf); out += right(tf)[:, None]
+    tf = self._af3_target_feat(s)
+    af3 = (tf @ left) + (tf @ right)[:, None, :]
+
+    np.testing.assert_allclose(af3, of3)
+
+  def test_evoformer_does_not_cross_i_and_j(self):
+    """The trunk uses the opposite naming, so there the direct mapping is right."""
+    s = self._single_input()
+    w_i, w_j = self._of3_weights()
+
+    # OF3: z = emb_i[..., None, :] + emb_j[..., None, :, :]
+    of3 = (s @ w_i.T)[:, None, :] + (s @ w_j.T)[None, :, :]
+
+    params = {}
+    sd = _marker_state_dict(c_out=2)
+    sd['input_embedder.linear_z_i.weight'] = w_i
+    sd['input_embedder.linear_z_j.weight'] = w_j
+    converter.map_evoformer_input_embeddings(sd, params)
+    left = params['diffuser/evoformer/left_single']['weights']
+    right = params['diffuser/evoformer/right_single']['weights']
+
+    # AF3: left_single[:, None] + right_single[None]
+    tf = self._af3_target_feat(s)
+    af3 = (tf @ left)[:, None, :] + (tf @ right)[None, :, :]
+
+    np.testing.assert_allclose(af3, of3)
+
+  def test_template_aatype_indices_are_crossed(self):
+    """AF3 index 2 is the column (j) projection, 3 the row (i) projection."""
+    idx_for = {
+        attr: int(idx)
+        for idx, attr in re.findall(
+            r'\((\d+), \'(aatype_linear_\d)\'\)',
+            _template_aatype_mapping_statement(),
+        )
+    }
+    self.assertEqual(idx_for, {'aatype_linear_1': 3, 'aatype_linear_2': 2})
+
+
+class CheckpointLayoutTest(parameterized.TestCase):
+  """Validates the hardcoded block offsets against a real OF3 checkpoint.
+
+  Skipped unless a checkpoint is found. Point ${OF3_CHECKPOINT} at an OF3
+  `.pt` file to run it.
+  """
+
+  @classmethod
+  def _checkpoint_path(cls) -> str | None:
+    candidates = [os.environ.get(_CHECKPOINT_ENV_VAR)]
+    candidates.extend(
+        os.path.join(_REPO_ROOT, p) for p in _CHECKPOINT_FALLBACKS
+    )
+    return next((p for p in candidates if p and os.path.exists(p)), None)
+
+  def setUp(self):
+    super().setUp()
+    path = self._checkpoint_path()
+    if path is None:
+      self.skipTest(
+          f'No OF3 checkpoint found; set ${_CHECKPOINT_ENV_VAR} to run.'
+      )
+    try:
+      import torch  # pylint: disable=g-import-not-at-top
+    except ImportError:
+      self.skipTest('PyTorch not installed.')
+    state_dict = torch.load(
+        path, map_location='cpu', weights_only=True, mmap=True
+    )
+    self._sd = state_dict.get('state_dict', state_dict)
+
+  @parameterized.named_parameters(
+      ('input_embedder_s', 'input_embedder.linear_s.weight', _S_INPUT_DIM),
+      ('input_embedder_z_i', 'input_embedder.linear_z_i.weight', _S_INPUT_DIM),
+      ('input_embedder_z_j', 'input_embedder.linear_z_j.weight', _S_INPUT_DIM),
+      (
+          'msa_s_input',
+          'msa_module_embedder.linear_s_input.weight',
+          _S_INPUT_DIM,
+      ),
+      ('msa_m', 'msa_module_embedder.linear_m.weight', _MSA_FEAT_DIM),
+      (
+          'confidence_i',
+          'aux_heads.pairformer_embedding.linear_i.weight',
+          _S_INPUT_DIM,
+      ),
+      (
+          'template_aatype_1',
+          'template_embedder.template_pair_embedder.aatype_linear_1.weight',
+          _NUM_OF3_RESTYPES,
+      ),
+      (
+          'diffusion_conditioning_s',
+          'diffusion_module.diffusion_conditioning.linear_s.weight',
+          _C_SINGLE + _S_INPUT_DIM,
+      ),
+  )
+  def test_input_dim_matches_assumed_layout(self, key, expected_in_dim):
+    self.assertIn(key, self._sd)
+    self.assertEqual(self._sd[key].shape[-1], expected_in_dim)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
Follow-up to b811498 (which fixed the MSA alphabet permutation and the two row/column pair-projection swaps). While auditing the port I found a fourth bug of the same family, and this PR adds the harness it was found with.

## The bug

OF3's restype and profile blocks carry 32 classes; AF3's carry 31, because AF3 folds unknown DNA into the shared unknown-nucleic class. Dropping that extra class from the converted weights is correct **everywhere else** — a zero input column contributes nothing to a bare `Linear`, which is why the trunk, MSA, confidence and template embeddings all agree to float32 noise.

It is wrong for `features_1d`. `single_cond_initial_norm` is a LayerNorm, so a zero input becomes `-mean/std`: OF3 always adds a trained contribution through those two columns, and normalises over **833** channels rather than 831. Both columns are now kept — the converter emits 833 rows and `diffusion_head` inserts matching zero columns under `of3_weights`.

Measured against the real OF3 module, the diffusion single conditioning goes from **2.2e-3 → 3.4e-7** relative error.

## Verification added

`src/alphafold3/model/of3_weight_converter_test.py` — 43 unit tests, no checkpoint required (the shape-contract class skips without one).

`scripts/of3_verification/` — structural audits plus module-level comparisons that run the real OF3 PyTorch modules against the real AF3 Haiku modules with converted weights. These catch the error classes no shape check can see: square-matrix transposes, SwiGLU gate-vs-value order, and block ordering inside a layer stack.

| module | relative error |
|---|---|
| trunk PairFormer block (0 and 47 of 48) | 2e-5 |
| MSA module block (0 and 3 of 4) | 3e-6 |
| diffusion transformer (all 24 blocks) | 3e-5 |
| template pair-stack block (0 and 1) | 2e-6 |
| confidence pairformer block (0 and 3 of 4) | 1e-5 |
| diffusion conditioning (Algorithm 21) | 4e-7 |
| pae / pde / plddt / experimentally-resolved / distogram heads | exactly 0 |

Covers 99% of the 368M converted parameters. Every checkpoint tensor is consumed except the bit-identical `sample_diffusion.*` duplicates. Each `compare_*` script honours `SABOTAGE=1` so you can confirm it discriminates before trusting a pass.

## Confirmed benign during the audit

* `sample_diffusion.*` is a bit-identical duplicate of `diffusion_module.*` (763 pairs, max|Δ| = 0)
* `_stack_blocks` zero-fill is an exact skip for OF3's last MSA block, which drops `msa_att_row`/`msa_transition`
* the 23-vs-24 atoms-per-token padding in the pLDDT / experimentally-resolved heads is unreachable (largest standard residue is RNA G at 23 heavy atoms)
* the duplicated non-`_1` atom pair-conditioning weights feed an AF3 code path whose result is discarded
* relative-position encoding layouts agree exactly, so `linear_relpos` needs no reordering

Also drops the unused `tri_mul_hidden` parameter and excludes `**_test.py` from the wheel.

## Notes for reviewers

- **Native AF3 behaviour is unchanged**: the `diffusion_head` edit is gated on `of3_weights`, and the converter only runs for `--of3_checkpoint`. Verified by diffing the full converted parameter tree against native AF3 params — the only shape differences are the two intended ones.
- **Weight files converted before this PR must be regenerated.** `single_cond_initial_norm` and `single_cond_initial_projection` changed shape, so an older converted file fails to load rather than silently misbehaving.
- The atom cross-attention transformers (~1% of params) are covered by the structural audits but not numerically: AF3's `CrossAttTransformer` needs a constructed `queries_to_keys` gather layout, and a hand-built stand-in risks a false result more than it buys confidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)