### PR TITLE
Build cp313 wheels for Colab's Python 3.13 runtime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,9 @@ jobs:
           - name-prefix: "all tests"
             python-version: '3.12'
             os: ubuntu-latest
+          - name-prefix: "all tests"
+            python-version: '3.13'
+            os: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/release_wheel.yaml
+++ b/.github/workflows/release_wheel.yaml
@@ -7,20 +7,27 @@ on:
 
 jobs:
   build-wheel:
-    name: Build manylinux wheel (cp312)
+    name: Build manylinux wheels (cp312, cp313)
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
 
-      - name: Build wheel
+      - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.0
         env:
-          CIBW_BUILD: cp312-manylinux_x86_64
+          CIBW_BUILD: cp312-manylinux_x86_64 cp313-manylinux_x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_BUILD_VERBOSITY: 1
 
-      - name: Upload wheel to release
+      - name: Upload wheels as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels
+          path: wheelhouse/alphafold3_open-*.whl
+
+      - name: Upload wheels to release
+        if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload ${{ github.ref_name }} wheelhouse/alphafold3_open-*.whl --clobber

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ sdist.include = [
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.setuptools_scm]
-fallback_version = "3.1.4"
+fallback_version = "3.1.5"
 
 [tool.cibuildwheel]
 build = "cp3*-manylinux_x86_64"


### PR DESCRIPTION
Colab upgraded its default runtime to Python 3.13 on 2026-08-25 ([colabtools#6081](https://github.com/googlecolab/colabtools/issues/6081)). The v3.1.4 release only shipped a `cp312` wheel, so the ColabFold notebook's `pip install <release wheel URL>` now fails:

```
ERROR: alphafold3_open-3.1.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
is not a supported wheel on this platform.
```

`cp312` is ABI-specific (pybind11 extension, not abi3), so pip on 3.13 correctly rejects it. The URL and manylinux tags were never the problem — Colab's glibc is 2.35.

## Changes

- `release_wheel.yaml` builds `cp312` **and** `cp313` manylinux_2_28 wheels
- wheels are also uploaded as a workflow artifact, and the release-upload step is gated on `github.event_name == 'release'`, so a `workflow_dispatch` run can be verified without cutting a tag
- `ci.yaml` gains a 3.13 matrix leg so this can't regress silently
- `fallback_version` -> 3.1.5

## Dependency check

Every runtime dep already ships cp313 wheels, so nothing else blocks 3.13:

| package | cp313 |
|---|---|
| `jaxlib` 0.10.1 / 0.10.2 | `cp313-cp313-manylinux_2_27_x86_64` |
| `jax-cuda12-plugin` 0.10.1 / 0.10.2 | `cp313-cp313-manylinux_2_27_x86_64` |
| `rdkit` 2025.9.4 | `cp313-cp313-manylinux_2_28_x86_64` |
| `jax`, `dm-haiku`, `tokamax` | `py3-none-any` |

The companion ColabFold notebook change stops hardcoding the interpreter tag, so the next Python bump won't break it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)