### PR TITLE
Add openbind porter

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -21,6 +21,11 @@ on:
         description: 'Tag prefix; the short commit is appended'
         required: true
         default: 'openbind'
+      weights:
+        description: 'Also build the -weights image (adds the converted OpenFold3 parameters under /models)'
+        type: boolean
+        required: true
+        default: true
 
 permissions:
   contents: read
@@ -69,6 +74,30 @@ jobs:
           provenance: false
           sbom: false
 
+      - name: Free the build cache before the second image
+        if: ${{ inputs.weights }}
+        # The base image was pushed, so the derived build pulls it from the
+        # registry; the builder cache is no longer needed and the convert stage
+        # wants room for torch plus the 2.2 GB checkpoint.
+        run: |
+          docker builder prune --all --force
+          df -h /
+
+      - name: Add the OpenFold3 openbind weights under /models
+        id: push_weights
+        if: ${{ inputs.weights }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.weights
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            BASE_IMAGE=ghcr.io/${{ steps.image.outputs.owner }}/alphafold3:${{ steps.image.outputs.tag }}
+          tags: ghcr.io/${{ steps.image.outputs.owner }}/alphafold3:${{ steps.image.outputs.tag }}-weights
+          provenance: false
+          sbom: false
+
       - name: Report how to pull it
         run: |
           IMAGE=ghcr.io/${{ steps.image.outputs.owner }}/alphafold3:${{ steps.image.outputs.tag }}
@@ -78,6 +107,10 @@ jobs:
             echo '```'
             echo "$IMAGE"
             echo "digest: ${{ steps.push.outputs.digest }}"
+            if [ -n '${{ steps.push_weights.outputs.digest }}' ]; then
+              echo "$IMAGE-weights   (adds the openbind parameters under /models)"
+              echo "digest: ${{ steps.push_weights.outputs.digest }}"
+            fi
             echo '```'
             echo ''
             echo 'On the cluster (login node):'
@@ -86,6 +119,13 @@ jobs:
             echo 'export APPTAINER_TMPDIR=/tmp/apptainer_pull.$$ && mkdir -p "$APPTAINER_TMPDIR"'
             echo "apptainer pull alphafold3_${{ steps.image.outputs.tag }}.sif docker://$IMAGE"
             echo 'rm -rf "$APPTAINER_TMPDIR"'
+            echo '```'
+            echo ''
+            echo 'The -weights image needs no model directory:'
+            echo ''
+            echo '```bash'
+            echo 'apptainer exec --nv IMAGE.sif python3 /app/alphafold/run_alphafold.py \\'
+            echo '    --model_dir=/models --of3_weights --json_path=... --output_dir=...'
             echo '```'
             echo ''
             echo 'The package is private on first push; make it public once under'

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -1,0 +1,93 @@
+# Build the container image batch-infer runs, from AlphaFold 3's own
+# docker/Dockerfile, and push it to this repository's GitHub package registry.
+#
+# Manual only: nothing is built on push. The runner is native x86_64, which is
+# the point - the image has to be linux/amd64 for the cluster, and emulating
+# that on an arm64 laptop makes the C++ extension build (236 targets, -flto)
+# take hours.
+#
+# Weights are never in the image, only Apache-2.0 code and the CCD tables.
+
+name: docker-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build'
+        required: true
+        default: 'add_openbind_porter'
+      tag_prefix:
+        description: 'Tag prefix; the short commit is appended'
+        required: true
+        default: 'openbind'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        # A runner has ~14 GB free on /, where Docker keeps its data. The CUDA
+        # base image, the CUDA wheels and the build tree together need more, so
+        # drop toolchains this build has no use for.
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          df -h /
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Name the image after the commit it was built from
+        id: image
+        run: |
+          echo "tag=${{ inputs.tag_prefix }}-$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+          echo "owner=$(echo '${{ github.repository_owner }}' | tr 'A-Z' 'a-z')" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        id: push
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ steps.image.outputs.owner }}/alphafold3:${{ steps.image.outputs.tag }}
+          # Attestations would turn the tag into a multi-manifest index, which
+          # `apptainer pull docker://...` does not handle cleanly.
+          provenance: false
+          sbom: false
+
+      - name: Report how to pull it
+        run: |
+          IMAGE=ghcr.io/${{ steps.image.outputs.owner }}/alphafold3:${{ steps.image.outputs.tag }}
+          {
+            echo "### Image"
+            echo ''
+            echo '```'
+            echo "$IMAGE"
+            echo "digest: ${{ steps.push.outputs.digest }}"
+            echo '```'
+            echo ''
+            echo 'On the cluster (login node):'
+            echo ''
+            echo '```bash'
+            echo 'export APPTAINER_TMPDIR=/tmp/apptainer_pull.$$ && mkdir -p "$APPTAINER_TMPDIR"'
+            echo "apptainer pull alphafold3_${{ steps.image.outputs.tag }}.sif docker://$IMAGE"
+            echo 'rm -rf "$APPTAINER_TMPDIR"'
+            echo '```'
+            echo ''
+            echo 'The package is private on first push; make it public once under'
+            echo 'Packages -> alphafold3 -> Package settings -> Change visibility.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/OF3_AF3_PORTING_NOTES.md
+++ b/OF3_AF3_PORTING_NOTES.md
@@ -7,7 +7,9 @@ reproduce or re-implement AlphaFold3 from the released source.
 **Repositories**
 - AF3 source: [sokrypton/alphafold3](https://github.com/sokrypton/alphafold3) (fork of google-deepmind/alphafold3)
 - OF3 source: [aqlaboratory/openfold3](https://github.com/aqlaboratory/openfold)
-- OF3 weights: `s3://openfold/staging/of3-p2-155k.pt` (public, no sign required)
+- OF3 weights: `s3://openfold3-data/openfold3-parameters/of3-ob-2025-06-30-174k.pt`
+  (OpenFold3 >= 0.5.0, "openbind") and `s3://openfold/staging/of3-p2-155k.pt`
+  (preview-2) — both public, no sign required
 
 ---
 
@@ -104,6 +106,43 @@ So mapping `linear_i → left` is **correct in the trunk and wrong in the confid
 **Checked and confirmed consistent** (no fix needed): the PAE/PDE bin decoding — AF3's `linspace(0, 31.0, 63)` + half-step + catch-all and OF3's `get_bin_centers(0, 32, 64)` both yield centers `0.25, 0.75, …, 31.75`; and the representative-atom choice feeding `linear_distance` — AF3's pseudo-beta (CB, CA for Gly, C4 for purines, C2 for pyrimidines, atom 0 for ligands) matches OF3's `get_token_representative_atoms` exactly.
 
 ---
+
+## Two OF3 checkpoint releases
+
+The port was written against preview-2 (`of3-p2-155k`). OpenFold3 >= 0.5.0
+("openbind", `of3-ob-2025-06-30-174k`) reverted two of the divergences it
+compensates for, so those two adjustments are switched off for openbind
+weights and left in force for preview-2. Everything else — the residue
+alphabet permutation, the element one-hot shift, the atom cross-attention
+masks, the bond symmetrisation, the i/j crossings, the Fourier buffers —
+applies to both.
+
+| what | preview-2 | openbind |
+|---|---|---|
+| Diffusion transformer pair LayerNorm | one per block, inside `attention_pair_bias` | one on the transformer, run once (AF3's own layout) |
+| Column attention pair bias | `Linear(z[k, q])` | `Linear(z[q, k])`, per AF3 Algorithm 15 |
+
+Consequences for the code:
+
+| File | openbind change |
+|---|---|
+| `model_config.py` | `GlobalConfig.of3_openbind`, gating the two preview-2-only branches |
+| `network/diffusion_transformer.py` | openbind takes AF3's shared-LayerNorm path; the per-block branch is preview-2 only |
+| `network/modules.py` | the `GridSelfAttention` bias axis swap is preview-2 only |
+| `of3_weight_converter.py` | openbind's shared LayerNorm scale and per-super-block pair-logits Linear go to AF3's `pair_input_layer_norm` and `__layer_stack_with_per_layer` scopes, rather than being stacked into each block |
+
+The release is detected from the checkpoint itself: openbind has
+`diffusion_module.diffusion_transformer.layer_norm_z.weight` and preview-2 has
+the same tensor once per block inside `attention_pair_bias`, so the two are
+mutually exclusive and no version string is needed. `convert_of3_weights.py`
+and `run_alphafold.py --of3_checkpoint` write the result to an `of3_variant`
+file next to the converted parameters, which is what a later
+`--model_dir`-only run reads; `--of3_openbind={auto,true,false}` overrides it.
+A wrong choice is caught rather than silently tolerated: the two layouts
+occupy different parameter scopes, so the run stops with `Unable to retrieve
+parameter 'scale' for module '.../transformer/pair_input_layer_norm'`. Both
+directions were checked (openbind weights forced to preview-2 and the reverse).
+The marker and the warning exist so this does not have to be diagnosed by hand.
 
 ## Verification
 
@@ -215,11 +254,11 @@ if self.transpose and self.global_config.of3_weights:
     nonbatched_bias = jnp.swapaxes(nonbatched_bias, -1, -2)
 ```
 
-Anyone reimplementing triangle attention ending node should use `Linear(z[q, k])` per the paper if training from scratch.
+Anyone reimplementing triangle attention ending node should use `Linear(z[q, k])` per the paper if training from scratch. OpenFold3 >= 0.5.0 did exactly that: `TriangleAttention.forward` gained a `transpose_bias` argument, set for the ending node, which restores the paper's ordering. The swap above is therefore applied only for preview-2 weights (`of3_openbind=False`).
 
 ### 4. Diffusion transformer pair conditioning (per-block vs. shared)
 
-OF3 applies a separate `LayerNorm + Linear` to the pair representation inside **each** diffusion transformer block. AF3's original code applied a single shared LayerNorm before all blocks. This is a genuine architectural difference that produces incompatible parameter layouts. If training AF3 from scratch, the choice must match whatever convention the weights were trained with.
+OF3 preview-2 applies a separate `LayerNorm + Linear` to the pair representation inside **each** diffusion transformer block. AF3's original code applied a single shared LayerNorm before all blocks. This is a genuine architectural difference that produces incompatible parameter layouts. If training AF3 from scratch, the choice must match whatever convention the weights were trained with. OpenFold3 >= 0.5.0 moved the pair LayerNorm out of attention pair bias and runs it once "to match the AlphaFold3 SI", so openbind weights use AF3's own shared layout and the per-block branch is preview-2 only.
 
 ### 5. Fourier noise embeddings
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,23 @@ https://storage.googleapis.com/alphafold3/af3.bin.zst. Use is subject to these
 
 [OpenFold3](https://github.com/aqlaboratory/openfold3), developed by the AlQuraishi Lab at Columbia University and the OpenFold Consortium, is an independent reproduction of AlphaFold 3 that has released model weights under the Apache 2.0 license. These weights can be used with this codebase as a freely available alternative to the Google DeepMind parameters.
 
+Two OpenFold3 releases are supported. They lay out the diffusion transformer's
+pair bias differently, and the code picks the right layout for whichever
+checkpoint you convert:
+
+| checkpoint | release |
+|---|---|
+| `of3-ob-2025-06-30-174k.pt` | OpenFold3 >= 0.5.0, "openbind" |
+| `of3-p2-155k.pt` | preview-2 |
+
 **Step 1 — Download OpenFold3 weights:**
 
 ```bash
+# openbind (OpenFold3 >= 0.5.0)
+aws s3 cp s3://openfold3-data/openfold3-parameters/of3-ob-2025-06-30-174k.pt . \
+  --no-sign-request
+
+# or preview-2
 wget https://openfold.s3.amazonaws.com/staging/of3-p2-155k.pt
 ```
 
@@ -49,11 +63,12 @@ A conversion script is included in this repository:
 
 ```bash
 python convert_of3_weights.py \
-  --of3_checkpoint ./of3-p2-155k.pt \
+  --of3_checkpoint ./of3-ob-2025-06-30-174k.pt \
   --output_dir ./af3_of3_params/
 ```
 
-This produces `af3_of3_params/of3_ported_weights.bin.zst` (~1.4 GB).
+This produces `af3_of3_params/of3_ported_weights.bin.zst` (~1.4 GB), alongside
+an `of3_variant` file naming the release the weights came from.
 
 **Step 3 — Run inference:**
 
@@ -66,6 +81,39 @@ python run_alphafold.py \
   --output_dir=./output/ \
   --of3_weights
 ```
+
+The release-specific settings come from the `of3_variant` file written in
+Step 2. If it is missing — weights converted by some other route — the run
+warns and assumes preview-2; pass `--of3_openbind=true` for openbind weights,
+or `--of3_openbind=false` to force preview-2. The wrong choice is not silent:
+the two releases keep the diffusion transformer's pair bias in different
+parameter scopes, so the run stops with `Unable to retrieve parameter 'scale'
+for module '.../transformer/pair_input_layer_norm'` instead of returning a
+structure.
+
+`run_alphafold.py --of3_checkpoint=./of3-ob-2025-06-30-174k.pt
+--model_dir=./af3_of3_params/` collapses Steps 2 and 3 — it converts on first
+use, caches the result in `--model_dir` and runs inference with the matching
+settings.
+
+**What has been checked.** The openbind weights have been exercised here on
+protein monomers and protein–protein complexes, run with precomputed MSAs
+(`--norun_data_pipeline`).
+
+Structural templates have been checked for a single protein chain. Given a
+full-coverage template inline in the input JSON, the prediction reproduces it —
+0.26 Å over 153 CA, TM 0.997, against 8.11 Å and TM 0.461 for the same input
+with no template — and confidence rises from pTM 0.58 to 0.95. AlphaFold 3's
+own weights respond by the same amount on the same input (0.21 Å, pTM 0.93).
+That shows the template path reaches the model and behaves as it does under
+AlphaFold 3's weights; it is not a measurement of template-based accuracy on a
+held-out target, since the template used was 99% identical to the query.
+
+Not covered by any check in this repository: DNA and RNA chains, ligands, ions,
+post-translational modifications and other covalent bonds, glycans, templates
+on more than one chain, and the full genetic database data pipeline. Those paths
+may well work — the conversion covers the corresponding weights — but nothing
+here demonstrates it, so treat them as unverified.
 
 The OpenFold3 weights are subject to the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0) and may be used for both academic and commercial purposes, without requiring a separate access request.
 

--- a/convert_of3_weights.py
+++ b/convert_of3_weights.py
@@ -56,6 +56,7 @@ def main() -> int:
         load_of3_checkpoint,
         map_of3_to_af3,
         save_af3_params,
+        write_variant_marker,
     )
 
     print(f'Loading {args.of3_checkpoint}  (use_ema={args.use_ema}) ...')
@@ -80,6 +81,7 @@ def main() -> int:
     t0 = time.perf_counter()
     out = save_af3_params(af3_params, args.output_dir)
     print(f'  {out}  ({out.stat().st_size/1e6:.0f} MB, {time.perf_counter()-t0:.1f}s)')
+    print(f'  OF3 variant: {write_variant_marker(args.output_dir, sd)}')
     print(f'\nDone. Use with:\n'
           f'  python run_alphafold.py --model_dir {args.output_dir} --of3_weights ...')
     return 0

--- a/docker/Dockerfile.weights
+++ b/docker/Dockerfile.weights
@@ -1,0 +1,65 @@
+# AlphaFold 3 + OpenFold3 openbind weights, ready to use.
+#
+# Derives from the image built by docker/Dockerfile (upstream AlphaFold 3's own,
+# unmodified) and adds the converted OpenFold3 openbind parameters under
+# /models, so a run needs no external weights directory:
+#
+#   apptainer exec IMAGE.sif python3 /app/alphafold/run_alphafold.py \
+#       --model_dir=/models --of3_weights ...
+#
+# The of3_variant marker travels with them, so the release is auto-detected and
+# --of3_openbind is not needed.
+#
+# Why a derived image rather than extra stages in docker/Dockerfile: that file
+# is byte-identical to google-deepmind/alphafold3's, which is what keeps merging
+# upstream free. This one only adds.
+#
+# Only the OpenFold3 weights are here (Apache-2.0, redistributable). Google's
+# AlphaFold 3 parameters are NOT and must never be added: they are licensed
+# per-user and may not be redistributed.
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS convert
+
+# The checkpoint is public; torch is only needed to read it, so both stay in
+# this throwaway stage rather than in the published image.
+ARG OF3_CHECKPOINT=of3-ob-2025-06-30-174k.pt
+ARG OF3_CHECKPOINT_URL=https://openfold3-data.s3.amazonaws.com/openfold3-parameters
+RUN uv pip install --python /alphafold3_venv/bin/python3 \
+        torch --index-url https://download.pytorch.org/whl/cpu \
+ && wget -q "${OF3_CHECKPOINT_URL}/${OF3_CHECKPOINT}" -O /tmp/${OF3_CHECKPOINT} \
+ && python3 /app/alphafold/convert_of3_weights.py \
+        --of3_checkpoint /tmp/${OF3_CHECKPOINT} --output_dir /models \
+ && rm /tmp/${OF3_CHECKPOINT} \
+ && ls -l /models && cat /models/of3_variant
+
+FROM ${BASE_IMAGE}
+ARG OF3_CHECKPOINT=of3-ob-2025-06-30-174k.pt
+ARG OF3_CHECKPOINT_URL=https://openfold3-data.s3.amazonaws.com/openfold3-parameters
+
+COPY --from=convert /models /models
+
+# Apache-2.0 requires the licence text and attribution to travel with the
+# weights. The text is the same document AlphaFold 3 ships; the NOTICE records
+# whose weights these are and where they came from.
+RUN cp /app/alphafold/LICENSE /models/LICENSE \
+ && printf '%s\n' \
+    'OpenFold3 model parameters' \
+    '' \
+    'of3_ported_weights.bin.zst holds the OpenFold3 "openbind" parameters' \
+    "(${OF3_CHECKPOINT}), converted from PyTorch to the AlphaFold 3 format by" \
+    'convert_of3_weights.py in this image. of3_variant records which OpenFold3' \
+    'release they are, and is read automatically by run_alphafold.py.' \
+    '' \
+    'Source:    '"${OF3_CHECKPOINT_URL}/${OF3_CHECKPOINT}" \
+    'Upstream:  https://github.com/aqlaboratory/openfold3' \
+    'Authors:   AlQuraishi Laboratory, Columbia University, and the OpenFold' \
+    '           Consortium' \
+    'Licence:   Apache License 2.0 (see LICENSE in this directory)' \
+    '' \
+    'This image contains no AlphaFold 3 model parameters from Google DeepMind.' \
+    > /models/NOTICE
+
+ENV OF3_OPENBIND_PARAMS=/models
+
+LABEL org.opencontainers.image.description="AlphaFold 3 with OpenFold3 openbind weights under /models"

--- a/run_alphafold.py
+++ b/run_alphafold.py
@@ -464,9 +464,11 @@ _OF3_CHECKPOINT = flags.DEFINE_string(
     'Path to an OpenFold3 .pt checkpoint file. When provided, the weights are'
     ' converted to AF3 format on first use and cached in --model_dir. The model'
     ' is then run with OF3-compatible settings (of3_weights=True). Weights are'
-    ' freely available from the public AWS bucket:\n'
-    '  aws s3 cp s3://openfold/staging/of3-p2-155k.pt ./of3-p2-155k.pt'
-    ' --no-sign-request',
+    ' freely available from the public AWS buckets:\n'
+    '  aws s3 cp s3://openfold3-data/openfold3-parameters/'
+    'of3-ob-2025-06-30-174k.pt . --no-sign-request  # OpenFold3 >= 0.5.0\n'
+    '  aws s3 cp s3://openfold/staging/of3-p2-155k.pt . --no-sign-request'
+    '  # preview-2',
 )
 _OF3_WEIGHTS = flags.DEFINE_bool(
     'of3_weights',
@@ -474,6 +476,15 @@ _OF3_WEIGHTS = flags.DEFINE_bool(
     'Use OF3-compatible model settings (of3_weights=True). Set automatically'
     ' when --of3_checkpoint is provided. Also set this flag when --model_dir'
     ' already points to a directory of pre-converted OF3 weights.',
+)
+_OF3_OPENBIND = flags.DEFINE_enum(
+    'of3_openbind',
+    'auto',
+    ['auto', 'true', 'false'],
+    'Whether the OF3 weights are openbind (OpenFold3 >= 0.5.0), which needs a'
+    ' different diffusion transformer layout than preview-2. "auto" reads the'
+    ' of3_variant marker written beside the converted weights in --model_dir.'
+    ' Only set this if that marker is missing or wrong.',
 )
 _NOJIT = flags.DEFINE_bool(
     'nojit',
@@ -514,6 +525,7 @@ def _maybe_convert_of3_weights(of3_checkpoint: str, model_dir: str) -> str:
       load_of3_checkpoint,
       map_of3_to_af3,
       save_af3_params,
+      write_variant_marker,
   )
 
   out_dir = pathlib.Path(model_dir)
@@ -535,6 +547,7 @@ def _maybe_convert_of3_weights(of3_checkpoint: str, model_dir: str) -> str:
   t0 = time.perf_counter()
   out = save_af3_params(af3_params, out_dir)
   print(f'  Saved {out}  ({out.stat().st_size/1e6:.0f} MB, {time.perf_counter()-t0:.1f}s)')
+  print(f'  OF3 variant: {write_variant_marker(out_dir, sd)}')
   return str(out_dir)
 
 
@@ -546,6 +559,7 @@ def make_model_config(
     return_embeddings: bool = False,
     return_distogram: bool = False,
     of3_weights: bool = False,
+    of3_openbind: bool = False,
 ) -> model.Model.Config:
   """Returns a model config with some defaults overridden."""
   config = model.Model.Config()
@@ -557,6 +571,7 @@ def make_model_config(
   config.return_embeddings = return_embeddings
   config.return_distogram = return_distogram
   config.global_config.of3_weights = of3_weights
+  config.global_config.of3_openbind = of3_openbind
   return config
 
 
@@ -1212,6 +1227,27 @@ def main(_):
     model_dir = _maybe_convert_of3_weights(_OF3_CHECKPOINT.value, model_dir)
     use_of3_weights = True
 
+  # Which OF3 layout the weights follow: the explicit flag wins, otherwise the
+  # marker written next to them at conversion time, otherwise preview-2.
+  use_of3_openbind = False
+  if use_of3_weights:
+    from alphafold3.model.of3_weight_converter import read_variant_marker
+
+    if _OF3_OPENBIND.value == 'auto':
+      variant = read_variant_marker(model_dir)
+      if variant is None:
+        print(
+            f'Warning: no of3_variant marker in {model_dir}; assuming'
+            ' preview-2 weights. Pass --of3_openbind=true if these are'
+            ' openbind (OpenFold3 >= 0.5.0) weights: the two releases keep the'
+            " diffusion transformer's pair bias in different parameter scopes,"
+            ' so the wrong choice stops on a missing parameter.'
+        )
+      use_of3_openbind = variant == 'openbind'
+    else:
+      use_of3_openbind = _OF3_OPENBIND.value == 'true'
+    print(f'OF3 weights: variant={"openbind" if use_of3_openbind else "p2"}')
+
   if not use_of3_weights:
     notice = textwrap.wrap(
         'Running AlphaFold 3. Please note that standard AlphaFold 3 model'
@@ -1252,6 +1288,7 @@ def main(_):
             return_embeddings=_SAVE_EMBEDDINGS.value,
             return_distogram=_SAVE_DISTOGRAM.value,
             of3_weights=use_of3_weights,
+            of3_openbind=use_of3_openbind,
         ),
         device=device,
         model_dir=model_dir,

--- a/src/alphafold3/model/model_config.py
+++ b/src/alphafold3/model/model_config.py
@@ -45,3 +45,10 @@ class GlobalConfig(base_config.BaseConfig):
   # When True, enables OpenFold3 weight compatibility mode.
   # Set to False (default) when using original AlphaFold3 weights.
   of3_weights: bool = False
+  # Which OpenFold3 checkpoint layout of3_weights refers to. OpenFold3 >= 0.5.0
+  # ("openbind") moved the diffusion transformer's pair LayerNorm out of
+  # attention pair bias and runs it once, and computes the column-attention
+  # pair bias from z the way AlphaFold3 does; both bring it back to
+  # AlphaFold3's own layout, so two preview-2 compatibility branches have to be
+  # switched off. Ignored unless of3_weights is True.
+  of3_openbind: bool = False

--- a/src/alphafold3/model/network/diffusion_transformer.py
+++ b/src/alphafold3/model/network/diffusion_transformer.py
@@ -216,10 +216,15 @@ class Transformer(hk.Module):
     assert self.config.num_blocks % self.config.super_block_size == 0
     num_super_blocks = self.config.num_blocks // self.config.super_block_size
 
-    if self.global_config.of3_weights and pair_cond is not None:
-      # OF3 mode: per-block pair LayerNorm + projection. pair_cond is shared
-      # across all blocks; each block in the layer_stack gets its own LN/Linear
-      # params stacked along axis 0.
+    if (
+        self.global_config.of3_weights
+        and not self.global_config.of3_openbind
+        and pair_cond is not None
+    ):
+      # OF3 preview-2 mode: per-block pair LayerNorm + projection. pair_cond is
+      # shared across all blocks; each block in the layer_stack gets its own
+      # LN/Linear params stacked along axis 0. openbind runs the pair LayerNorm
+      # once, so it takes AF3's own path below.
       def block(act):  # pylint: disable=function-redefined
         pair_act = hm.LayerNorm(
             name='pair_input_layer_norm',

--- a/src/alphafold3/model/network/modules.py
+++ b/src/alphafold3/model/network/modules.py
@@ -226,9 +226,14 @@ class GridSelfAttention(hk.Module):
         self.config.num_head, use_bias=False, name='pair_bias_projection'
     )(act)
     nonbatched_bias = jnp.transpose(nonbatched_bias, [2, 0, 1])
-    # OpenFold3 computes the pair bias from transposed z for column-wise attention;
-    # swap axes to match that convention when of3_weights=True.
-    if self.transpose and self.global_config.of3_weights:
+    # OpenFold3 preview-2 computed the pair bias from transposed z for
+    # column-wise attention; swap axes to match that convention. openbind
+    # indexes z the way AF3 does (Algorithm 15), so it keeps AF3's own axes.
+    if (
+        self.transpose
+        and self.global_config.of3_weights
+        and not self.global_config.of3_openbind
+    ):
       nonbatched_bias = jnp.swapaxes(nonbatched_bias, -1, -2)
 
     num_residues = act.shape[0]

--- a/src/alphafold3/model/of3_weight_converter.py
+++ b/src/alphafold3/model/of3_weight_converter.py
@@ -7,6 +7,11 @@ Implements the 5 systematic mapping rules:
   4. SwiGLU weight concatenation (linear_a ++ linear_b → transition1)
   5. Layer stack aggregation (N separate blocks → (N, ...) stacked tensors)
 
+Two OF3 checkpoint layouts are supported, told apart by
+`is_openbind_checkpoint`: preview-2 (`of3-p2-155k`) and openbind (OpenFold3
+>= 0.5.0, e.g. `of3-ob-2025-06-30-174k`), which runs the diffusion
+transformer's pair LayerNorm once rather than once per block.
+
 No dependency on OpenFold3 source code — only PyTorch and NumPy are required
 to run the conversion.
 """
@@ -167,6 +172,22 @@ def _get(sd: dict, key: str) -> np.ndarray:
 
 def _has(sd: dict, key: str) -> bool:
     return key in sd
+
+
+# ─── Checkpoint variants ──────────────────────────────────────────────────────
+
+# openbind hoisted the diffusion transformer's pair LayerNorm out of
+# attention_pair_bias and runs it once, storing it as a single tensor on the
+# transformer; preview-2 stores one per block. Presence of the shared tensor is
+# therefore an unambiguous one-key signature, and needs no version string.
+_OPENBIND_SHARED_PAIR_NORM_KEY = (
+    'diffusion_module.diffusion_transformer.layer_norm_z.weight'
+)
+
+
+def is_openbind_checkpoint(sd: dict) -> bool:
+    """True for an openbind (OpenFold3 >= 0.5.0) checkpoint, False for preview-2."""
+    return _has(sd, _OPENBIND_SHARED_PAIR_NORM_KEY)
 
 
 # ─── Parameter dict helpers ───────────────────────────────────────────────────
@@ -527,15 +548,17 @@ def _diff_cond_transition_params(sd: dict, prefix: str, name: str) -> dict[str, 
 
 
 def convert_diff_self_attn_block(sd: dict, block_idx: int, prefix_base: str,
-                                  name: str, H: int, D: int) -> dict[str, np.ndarray]:
+                                  name: str, H: int, D: int, *,
+                                  per_block_pair_bias: bool = True) -> dict[str, np.ndarray]:
     pa = f'{prefix_base}.blocks.{block_idx}.attention_pair_bias'
     pt = f'{prefix_base}.blocks.{block_idx}.conditioned_transition'
     d = {}
     d.update(_diff_adaln_params(sd, f'{pa}.layer_norm_a', name))
-    # Per-block pair LayerNorm + projection stored without name prefix to match
-    # bare hm.LayerNorm(name='pair_input_layer_norm') in diffusion_transformer.py
-    d['pair_input_layer_norm/scale'] = _get(sd, f'{pa}.layer_norm_z.weight')
-    d['pair_logits_projection/weights'] = _t(_get(sd, f'{pa}.linear_z.weight'))
+    if per_block_pair_bias:
+        # Per-block pair LayerNorm + projection stored without name prefix to match
+        # bare hm.LayerNorm(name='pair_input_layer_norm') in diffusion_transformer.py
+        d['pair_input_layer_norm/scale'] = _get(sd, f'{pa}.layer_norm_z.weight')
+        d['pair_logits_projection/weights'] = _t(_get(sd, f'{pa}.linear_z.weight'))
     qw = _get(sd, f'{pa}.mha.linear_q.weight')
     d[f'{name}q_projection/weights'] = qw.T.reshape(-1, H, D)
     d[f'{name}q_projection/bias'] = _get(sd, f'{pa}.mha.linear_q.bias').reshape(H, D)
@@ -588,10 +611,27 @@ def _pair_logits_flat(sd: dict, prefix_base: str, n_blocks: int) -> np.ndarray:
     )
 
 
+def _pair_logits_super_blocks(sd: dict, prefix_base: str, n_blocks: int,
+                                n_super: int) -> np.ndarray:
+    """Pair-logits weights grouped the way AF3 stores them, per super block.
+
+    AF3 gives each super block a single Linear emitting the pair logits of all
+    of its blocks at once, so the stacked weights are
+    (n_super, c_z, super_block_size, num_head). OF3 keeps one Linear per block,
+    with block ``s * super_block_size + b`` belonging to super block ``s``.
+    """
+    flat = _pair_logits_flat(sd, prefix_base, n_blocks)  # (c_z, n_blocks, num_head)
+    c_z, _, num_head = flat.shape
+    grouped = flat.reshape(c_z, n_super, n_blocks // n_super, num_head)
+    return grouped.transpose(1, 0, 2, 3)
+
+
 def _stack_main_transformer(sd: dict, prefix_base: str, name: str,
-                              n_blocks: int, n_super: int, H: int, D: int) -> dict[str, np.ndarray]:
+                              n_blocks: int, n_super: int, H: int, D: int, *,
+                              per_block_pair_bias: bool = True) -> dict[str, np.ndarray]:
     super_size = n_blocks // n_super
-    all_blocks = [convert_diff_self_attn_block(sd, i, prefix_base, name, H, D)
+    all_blocks = [convert_diff_self_attn_block(sd, i, prefix_base, name, H, D,
+                                                per_block_pair_bias=per_block_pair_bias)
                   for i in range(n_blocks)]
     result = {}
     for key in all_blocks[0]:
@@ -774,9 +814,24 @@ def map_diffusion_head(sd: dict, params: dict, *,
     tr_base = f'{dm}.diffusion_transformer'
     tr_name = 'transformer'
     tr_scope = f'{scope}/{tr_name}'
-    tr_stacked = _stack_main_transformer(sd, tr_base, tr_name, n_diff_blocks, n_super_blocks, diff_H, diff_D)
-    tr_inner = f'{tr_scope}/__layer_stack_no_per_layer/__layer_stack_no_per_layer'
-    _populate_scope(params, tr_inner, tr_stacked)
+    openbind = is_openbind_checkpoint(sd)
+    tr_stacked = _stack_main_transformer(sd, tr_base, tr_name, n_diff_blocks,
+                                         n_super_blocks, diff_H, diff_D,
+                                         per_block_pair_bias=not openbind)
+    if openbind:
+        # A single pair LayerNorm and one pair-logits Linear per super block:
+        # stock AF3's own layout, so both hang off the transformer itself and
+        # the blocks go into the with_per_layer scopes.
+        tag = '__layer_stack_with_per_layer'
+        _populate_scope(params, f'{tr_scope}/{tag}/{tag}', tr_stacked)
+        _set(params, f'{tr_scope}/pair_input_layer_norm', 'scale',
+             _get(sd, f'{tr_base}.layer_norm_z.weight'))
+        _set(params, f'{tr_scope}/{tag}/pair_logits_projection', 'weights',
+             _pair_logits_super_blocks(sd, tr_base, n_diff_blocks, n_super_blocks))
+    else:
+        # preview-2 carries a pair LayerNorm and projection inside every block.
+        tr_inner = f'{tr_scope}/__layer_stack_no_per_layer/__layer_stack_no_per_layer'
+        _populate_scope(params, tr_inner, tr_stacked)
 
     _set(params, f'{scope}/single_cond_embedding_norm', 'scale', _get(sd, f'{dm}.layer_norm_s.weight'))
     _set(params, f'{scope}/single_cond_embedding_projection', 'weights', _t(_get(sd, f'{dm}.linear_s.weight')))
@@ -864,6 +919,29 @@ def load_of3_checkpoint(ckpt_path: Path | str, use_ema: bool = True) -> dict:
         (k[len('model.'):] if k.startswith('model.') else k): v
         for k, v in state_dict.items()
     }
+
+
+# Written next to the converted params so a later --model_dir-only run can tell
+# which OF3 layout they came from without the checkpoint at hand.
+VARIANT_MARKER_FILENAME = 'of3_variant'
+
+
+def checkpoint_variant(sd: dict) -> str:
+    """Name of the checkpoint's layout, 'openbind' or 'p2'."""
+    return 'openbind' if is_openbind_checkpoint(sd) else 'p2'
+
+
+def write_variant_marker(output_dir: Path | str, sd: dict) -> str:
+    """Record the checkpoint's layout beside its converted params."""
+    variant = checkpoint_variant(sd)
+    (Path(output_dir) / VARIANT_MARKER_FILENAME).write_text(variant + '\n')
+    return variant
+
+
+def read_variant_marker(model_dir: Path | str) -> str | None:
+    """Read back write_variant_marker; None if the directory has no marker."""
+    marker = Path(model_dir) / VARIANT_MARKER_FILENAME
+    return marker.read_text().strip() if marker.exists() else None
 
 
 def save_af3_params(params: dict[str, dict[str, np.ndarray]], output_dir: Path | str) -> Path:

--- a/src/alphafold3/model/of3_weight_converter_test.py
+++ b/src/alphafold3/model/of3_weight_converter_test.py
@@ -30,6 +30,11 @@ AF3 class c end up pulling from". That is checked against AF3's real featurizers
 (`msa_features`, `residue_names`), which makes these behavioural tests rather
 than a restatement of the converter's internal tables.
 
+The same file also converts the two OF3 checkpoint layouts - preview-2 and
+openbind (OpenFold3 >= 0.5.0) - whose diffusion transformers store the pair
+bias differently; `CheckpointVariantTest` and `DiffusionTransformerLayoutTest`
+cover telling them apart and mapping each one.
+
 Neither the openfold3 package nor an OF3 checkpoint is required. The OF3
 alphabet is transcribed from `openfold3/core/data/resources/residues.py`
 (`STANDARD_RESIDUES_WITH_GAP_3`). `CheckpointLayoutTest` optionally validates
@@ -128,6 +133,97 @@ def _template_aatype_mapping_statement() -> str:
       if 'aatype_linear_1' in line and line.lstrip().startswith('for ')
   )
   return '\n'.join(lines[idx : idx + 3])
+
+
+# Toy diffusion transformer dimensions. Small enough to write out by hand,
+# but with every axis a different length so a wrong reshape cannot pass.
+_TOY_N_BLOCKS = 6
+_TOY_N_SUPER = 3
+_TOY_NUM_HEAD = 2
+_TOY_HEAD_DIM = 3
+_TOY_C_Z = 5
+_TOY_C_SINGLE = 4
+_TOY_ACT = _TOY_NUM_HEAD * _TOY_HEAD_DIM  # 6
+
+# Real key prefix: the toy state dicts and a real checkpoint are read the same
+# way, so the variant checks below apply to both.
+_DIFF_TRANSFORMER_PREFIX = 'diffusion_module.diffusion_transformer'
+
+# The two tensors that move between the layouts: preview-2 keeps a pair
+# LayerNorm inside every block, openbind keeps one on the transformer. The
+# per-block pair *projection* stays per block in both.
+_PER_BLOCK_PAIR_NORM = 'attention_pair_bias.layer_norm_z.weight'
+_PER_BLOCK_PAIR_PROJ = 'attention_pair_bias.linear_z.weight'
+
+
+def _toy_diff_transformer_state_dict(
+    per_block_pair_norm: bool = True,
+) -> dict[str, np.ndarray]:
+  """Self-attention blocks of a diffusion transformer, in OF3 (out, in) layout.
+
+  Every tensor is drawn from one seeded generator, so each one is distinct and
+  a parameter that ends up in the wrong scope is visible.
+  """
+  rng = np.random.default_rng(0)
+
+  def w(*shape: int) -> np.ndarray:
+    return rng.standard_normal(shape).astype(np.float32)
+
+  def adaln(prefix: str) -> dict[str, np.ndarray]:
+    return {
+        f'{prefix}.layer_norm_s.weight': w(_TOY_C_SINGLE),
+        f'{prefix}.linear_g.weight': w(_TOY_ACT, _TOY_C_SINGLE),
+        f'{prefix}.linear_g.bias': w(_TOY_ACT),
+        f'{prefix}.linear_s.weight': w(_TOY_ACT, _TOY_C_SINGLE),
+    }
+
+  sd = {}
+  for block in range(_TOY_N_BLOCKS):
+    pa = f'{_DIFF_TRANSFORMER_PREFIX}.blocks.{block}.attention_pair_bias'
+    pt = f'{_DIFF_TRANSFORMER_PREFIX}.blocks.{block}.conditioned_transition'
+    sd.update(adaln(f'{pa}.layer_norm_a'))
+    if per_block_pair_norm:
+      sd[f'{pa}.layer_norm_z.weight'] = w(_TOY_C_Z)
+    sd[f'{pa}.linear_z.weight'] = w(_TOY_NUM_HEAD, _TOY_C_Z)
+    for name in ('q', 'k', 'v', 'g', 'o'):
+      sd[f'{pa}.mha.linear_{name}.weight'] = w(_TOY_ACT, _TOY_ACT)
+    sd[f'{pa}.mha.linear_q.bias'] = w(_TOY_ACT)
+    sd[f'{pa}.linear_ada_out.weight'] = w(_TOY_ACT, _TOY_ACT)
+    sd[f'{pa}.linear_ada_out.bias'] = w(_TOY_ACT)
+    sd.update(adaln(f'{pt}.layer_norm'))
+    sd[f'{pt}.swiglu.linear_a.weight'] = w(2 * _TOY_ACT, _TOY_ACT)
+    sd[f'{pt}.swiglu.linear_b.weight'] = w(2 * _TOY_ACT, _TOY_ACT)
+    sd[f'{pt}.linear_out.weight'] = w(_TOY_ACT, 2 * _TOY_ACT)
+    sd[f'{pt}.linear_g.weight'] = w(_TOY_ACT, _TOY_ACT)
+    sd[f'{pt}.linear_g.bias'] = w(_TOY_ACT)
+  if not per_block_pair_norm:
+    sd[f'{_DIFF_TRANSFORMER_PREFIX}.layer_norm_z.weight'] = w(_TOY_C_Z)
+  return sd
+
+
+def _convert_toy_block(sd: dict, **kwargs) -> dict[str, np.ndarray]:
+  return converter.convert_diff_self_attn_block(
+      sd,
+      0,
+      _DIFF_TRANSFORMER_PREFIX,
+      'transformer',
+      _TOY_NUM_HEAD,
+      _TOY_HEAD_DIM,
+      **kwargs,
+  )
+
+
+def _network_source(filename: str) -> str:
+  """Source of a file in model/network, read rather than imported.
+
+  Importing those modules pulls in the CCD pickles that `build_data` writes;
+  the rest of this file needs neither them nor a checkpoint.
+  """
+  path = os.path.join(
+      os.path.dirname(os.path.abspath(converter.__file__)), 'network', filename
+  )
+  with open(path) as f:
+    return f.read()
 
 
 def _converted_source_rows(param_scope: str) -> np.ndarray:
@@ -493,6 +589,144 @@ class PairEmbeddingIndexConventionTest(parameterized.TestCase):
     self.assertEqual(idx_for, {'aatype_linear_1': 3, 'aatype_linear_2': 2})
 
 
+class CheckpointVariantTest(parameterized.TestCase):
+  """Telling openbind (OpenFold3 >= 0.5.0) and preview-2 checkpoints apart.
+
+  Getting this backwards is caught, but only once the model runs: the two
+  layouts put the diffusion transformer's pair bias in different parameter
+  scopes, so the run stops on a missing parameter. The signature is therefore
+  a single tensor that only one of the two layouts has, rather than a version
+  string.
+  """
+
+  _SHARED_PAIR_NORM = f'{_DIFF_TRANSFORMER_PREFIX}.layer_norm_z.weight'
+  _BLOCK_PAIR_NORM = f'{_DIFF_TRANSFORMER_PREFIX}.blocks.0.{_PER_BLOCK_PAIR_NORM}'
+
+  def test_shared_pair_layer_norm_reads_as_openbind(self):
+    sd = {self._SHARED_PAIR_NORM: np.zeros(_TOY_C_Z, dtype=np.float32)}
+    self.assertTrue(converter.is_openbind_checkpoint(sd))
+    self.assertEqual(converter.checkpoint_variant(sd), 'openbind')
+
+  def test_per_block_pair_layer_norm_reads_as_preview2(self):
+    sd = {self._BLOCK_PAIR_NORM: np.zeros(_TOY_C_Z, dtype=np.float32)}
+    self.assertFalse(converter.is_openbind_checkpoint(sd))
+    self.assertEqual(converter.checkpoint_variant(sd), 'p2')
+
+  @parameterized.named_parameters(
+      ('openbind', False, 'openbind'),
+      ('preview2', True, 'p2'),
+  )
+  def test_toy_state_dicts_are_recognised(self, per_block_pair_norm, expected):
+    sd = _toy_diff_transformer_state_dict(per_block_pair_norm)
+    self.assertEqual(converter.checkpoint_variant(sd), expected)
+
+  def test_marker_round_trips_through_the_params_directory(self):
+    """A run given only --model_dir has to recover the variant from disk."""
+    params_dir = self.create_tempdir().full_path
+    self.assertIsNone(converter.read_variant_marker(params_dir))
+
+    sd = _toy_diff_transformer_state_dict(per_block_pair_norm=False)
+    self.assertEqual(converter.write_variant_marker(params_dir, sd), 'openbind')
+    self.assertEqual(converter.read_variant_marker(params_dir), 'openbind')
+
+
+class DiffusionTransformerLayoutTest(parameterized.TestCase):
+  """Mapping each layout's diffusion transformer pair bias.
+
+  preview-2 runs a pair LayerNorm inside every block, so its scale and the
+  pair-logits projection are stacked with the block parameters. openbind runs
+  the LayerNorm once, which is stock AF3's own layout: the scale hangs off the
+  transformer and AF3 gives each super block one Linear emitting the pair
+  logits of all its blocks at once.
+  """
+
+  def test_openbind_block_drops_only_the_pair_bias_parameters(self):
+    sd = _toy_diff_transformer_state_dict()
+
+    with_pair = _convert_toy_block(sd)
+    without_pair = _convert_toy_block(sd, per_block_pair_bias=False)
+
+    self.assertEqual(
+        set(with_pair) - set(without_pair),
+        {'pair_input_layer_norm/scale', 'pair_logits_projection/weights'},
+    )
+    self.assertEmpty(set(without_pair) - set(with_pair))
+    for key, value in without_pair.items():
+      with self.subTest(param=key):
+        np.testing.assert_array_equal(value, with_pair[key])
+
+  def test_preview2_block_carries_the_pair_bias_parameters(self):
+    sd = _toy_diff_transformer_state_dict()
+    pa = f'{_DIFF_TRANSFORMER_PREFIX}.blocks.0.attention_pair_bias'
+
+    converted = _convert_toy_block(sd)
+
+    np.testing.assert_array_equal(
+        converted['pair_input_layer_norm/scale'],
+        sd[f'{pa}.layer_norm_z.weight'],
+    )
+    np.testing.assert_array_equal(
+        converted['pair_logits_projection/weights'],
+        sd[f'{pa}.linear_z.weight'].T,
+    )
+
+  def test_openbind_checkpoint_has_no_per_block_pair_layer_norm_to_read(self):
+    """Asking for the preview-2 layout has to fail, not silently drop weights."""
+    sd = _toy_diff_transformer_state_dict(per_block_pair_norm=False)
+
+    self.assertIsNotNone(_convert_toy_block(sd, per_block_pair_bias=False))
+    with self.assertRaises(KeyError):
+      _convert_toy_block(sd)
+
+  def test_pair_logits_are_grouped_by_super_block(self):
+    sd = _toy_diff_transformer_state_dict(per_block_pair_norm=False)
+    super_size = _TOY_N_BLOCKS // _TOY_N_SUPER
+
+    grouped = converter._pair_logits_super_blocks(  # pylint: disable=protected-access
+        sd, _DIFF_TRANSFORMER_PREFIX, _TOY_N_BLOCKS, _TOY_N_SUPER
+    )
+
+    self.assertEqual(
+        grouped.shape,
+        (_TOY_N_SUPER, _TOY_C_Z, super_size, _TOY_NUM_HEAD),
+    )
+    for super_block in range(_TOY_N_SUPER):
+      for block in range(super_size):
+        with self.subTest(super_block=super_block, block=block):
+          index = super_block * super_size + block
+          np.testing.assert_array_equal(
+              grouped[super_block, :, block, :],
+              sd[f'{_DIFF_TRANSFORMER_PREFIX}.blocks.{index}.{_PER_BLOCK_PAIR_PROJ}'].T,
+          )
+
+
+class Preview2ModelBranchTest(parameterized.TestCase):
+  """The two preview-2-only model branches must stay gated on of3_openbind.
+
+  Both compensate for something openbind reverted to AF3's own convention. The
+  diffusion transformer's per-block pair LayerNorm changes which parameter
+  scopes are read, so leaving it on for openbind weights raises. The column
+  attention pair bias axis swap changes no shape at all, so leaving that one on
+  corrupts the fold silently - which is why it is gated here rather than left
+  to fail somewhere. Every *other* of3_weights branch (model.py,
+  atom_cross_attention.py, evoformer.py, diffusion_head.py) applies to both
+  checkpoints and must not be gated.
+
+  Driving the modules would need a built model, so check the source: these two
+  files hold one of3_weights branch each, which has to name of3_openbind.
+  """
+
+  @parameterized.named_parameters(
+      ('diffusion_transformer_pair_layer_norm', 'diffusion_transformer.py'),
+      ('column_attention_pair_bias', 'modules.py'),
+  )
+  def test_the_of3_weights_branch_is_gated_on_of3_openbind(self, filename):
+    source = _network_source(filename)
+
+    self.assertEqual(source.count('of3_weights'), 1)
+    self.assertEqual(source.count('of3_openbind'), 1)
+
+
 class CheckpointLayoutTest(parameterized.TestCase):
   """Validates the hardcoded block offsets against a real OF3 checkpoint.
 
@@ -553,6 +787,16 @@ class CheckpointLayoutTest(parameterized.TestCase):
   def test_input_dim_matches_assumed_layout(self, key, expected_in_dim):
     self.assertIn(key, self._sd)
     self.assertEqual(self._sd[key].shape[-1], expected_in_dim)
+
+  def test_exactly_one_pair_layer_norm_layout_is_present(self):
+    """The variant signature is only unambiguous if the layouts are exclusive."""
+    shared = f'{_DIFF_TRANSFORMER_PREFIX}.layer_norm_z.weight'
+    per_block = f'{_DIFF_TRANSFORMER_PREFIX}.blocks.0.{_PER_BLOCK_PAIR_NORM}'
+
+    self.assertNotEqual(shared in self._sd, per_block in self._sd)
+    self.assertEqual(
+        converter.is_openbind_checkpoint(self._sd), shared in self._sd
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Context
Openfold3 released new weights: [of3-ob-2025-06-30-174k.pt](https://github.com/aqlaboratory/openfold-3/releases/tag/v0.5.0) (called openbind)
This claude-vibe-coded PR adds support for the new openbind weights while keeping backwards compatibility to the old openfold-preview-weights.

  ### What changed

  ~150 lines of code; the rest is tests and docs. Usage unchanged: `--of3_weights`
  with a converted `--model_dir`, release detected automatically.

  - openbind reverted two OpenFold3 deviations back to AlphaFold 3's conventions (pair LayerNorm runs once, not per block; column pair bias follows Algorithm 15), so both compensations are now gated on a new `GlobalConfig.of3_openbind`.
  - The converter detects the release from the one tensor only openbind has, and maps its shared LayerNorm and per-super-block pair-logits weights into AlphaFold 3's own scopes.
  - Conversion writes an `of3_variant` marker that `run_alphafold.py` reads, so there are no extra flags; `--of3_openbind={auto,true,false}` overrides it.

  ### What has been tested

  On an NVIDIA RTX PRO 6000 Blackwell Server Edition (96 GB) — the only hardware
  used here; nothing ran on A100s.
  - tested with respect to monomer and protein complex folding - can fold complexes with input length of 5000aa (not tested for greater than 5000aa) with af3-native-close accuracy (accuracy slightly lower)
  - Untested: nucleic acids, ligands, ions, PTMs, glycans, multi-chain templates, full data pipeline.



